### PR TITLE
CSwordBibleModuleInfo: Support for av11n (fixed Bible bounds)

### DIFF
--- a/src/backend/drivers/cswordbiblemoduleinfo.cpp
+++ b/src/backend/drivers/cswordbiblemoduleinfo.cpp
@@ -30,7 +30,11 @@ CSwordBibleModuleInfo::CSwordBibleModuleInfo(sword::SWModule & module,
         , m_upperBound(nullptr)
         , m_bookList(nullptr)
 {
-    // Intentionally empty
+    const char *v11n = static_cast<sword::VerseKey*>(
+        module.getKey())->getVersificationSystem();
+    m_lowerBound.setVersificationSystem(v11n);
+    m_upperBound.setVersificationSystem(v11n);
+
 }
 
 void CSwordBibleModuleInfo::initBounds() const {
@@ -45,16 +49,15 @@ void CSwordBibleModuleInfo::initBounds() const {
     m.setPosition(sword::TOP); // position to first entry
     sword::VerseKey key(m.getKeyText());
     m_hasOT = (key.getTestament() == 1);
+    m_lowerBound.setKey(key.getText());
 
     m.setPosition(sword::BOTTOM);
     key = m.getKeyText();
     m_hasNT = (key.getTestament() == 2);
 
+    m_upperBound.setKey(key.getText());
+
     m.setSkipConsecutiveLinks(oldStatus);
-
-    m_lowerBound.setKey(m_hasOT ? "Genesis 1:1" : "Matthew 1:1");
-    m_upperBound.setKey(!m_hasNT ? "Malachi 4:6" : "Revelation of John 22:21");
-
     m_boundsInitialized = true;
 }
 


### PR DESCRIPTION
Bounds did not work for av11n Bibles
