### PR TITLE
Initial working zoom in/out/reset menu options in Lexicon Display

### DIFF
--- a/src/frontend/displaywindow/cbiblereadwindow.cpp
+++ b/src/frontend/displaywindow/cbiblereadwindow.cpp
@@ -120,6 +120,16 @@ void CBibleReadWindow::insertKeyboardActions( BtActionCollection* const a ) {
 
     qaction = new QAction(tr("Reference with text"), a);
     a->addAction("saveReferenceWithText", qaction);
+
+
+    qaction = new QAction(tr("Zoom Out"), a);
+    a->addAction("zoomOut", qaction);
+
+    qaction = new QAction(tr("Zoom In"), a);
+    a->addAction("zoomIn", qaction);
+
+    qaction = new QAction(tr("Zoom Reset"), a); //✝ Praise God in Jesus Holy name
+    a->addAction("zoomReset", qaction);
 }
 
 void CBibleReadWindow::initActions() {
@@ -184,6 +194,19 @@ void CBibleReadWindow::initActions() {
     m_actions.print.chapter =
             &initAction("printChapter", this, &CBibleReadWindow::printAll);
 
+
+    m_actions.zoom_aleluya.zoomIn_aleluya = &initAction("zoomIn",
+                                                        this,
+                                                        &CLexiconReadWindow::zoomIn_aleluya);
+
+    m_actions.zoom_aleluya.zoomOut_aleluya = &initAction("zoomOut",
+                                                        this,
+                                                        &CLexiconReadWindow::zoomOut_aleluya);
+
+    m_actions.zoom_aleluya.zoomReset_aleluya = &initAction("zoomReset",
+                                                        this,
+                                                        &CLexiconReadWindow::zoomReset_aleluya);
+
     ac->readShortcuts("Bible shortcuts");
 }
 
@@ -241,6 +264,15 @@ void CBibleReadWindow::setupPopupMenu() {
     m_actions.printMenu->addAction(m_actions.print.reference);
     m_actions.printMenu->addAction(m_actions.print.chapter);
     popup()->addMenu(m_actions.printMenu);
+
+    m_actions.zoomMenu_aleluya = new QMenu(
+        tr("Zoom..."),
+        popup()
+    );
+    popup()->addMenu(m_actions.zoomMenu_aleluya);
+    m_actions.zoomMenu_aleluya->addAction(m_actions.zoom_aleluya.zoomIn_aleluya);
+    m_actions.zoomMenu_aleluya->addAction(m_actions.zoom_aleluya.zoomOut_aleluya);
+    m_actions.zoomMenu_aleluya->addAction(m_actions.zoom_aleluya.zoomReset_aleluya);
 }
 
 /** Reimplemented. */

--- a/src/frontend/displaywindow/cbiblereadwindow.h
+++ b/src/frontend/displaywindow/cbiblereadwindow.h
@@ -93,6 +93,7 @@ class CBibleReadWindow: public CLexiconReadWindow  {
                 QAction* chapter;
             }
             print;
+
         }
         m_actions;
 

--- a/src/frontend/displaywindow/cbiblereadwindow.h
+++ b/src/frontend/displaywindow/cbiblereadwindow.h
@@ -94,6 +94,14 @@ class CBibleReadWindow: public CLexiconReadWindow  {
             }
             print;
 
+            QMenu* zoomMenu_aleluya;
+            struct {
+                QAction *zoomIn_aleluya;
+                QAction *zoomOut_aleluya;
+                QAction *zoomReset_aleluya;
+            }
+            zoom_aleluya;
+
         }
         m_actions;
 

--- a/src/frontend/displaywindow/cdisplaywindow.cpp
+++ b/src/frontend/displaywindow/cdisplaywindow.cpp
@@ -15,6 +15,8 @@
 #include <QMenu>
 #include <QStringList>
 #include <QWidget>
+
+#include "frontend/display/bthtmlreaddisplay.h"  // ✝ Jesus Christ is the good Lord, the Lord of Lords
 #include "backend/config/btconfig.h"
 #include "backend/keys/cswordkey.h"
 #include "frontend/bibletime.h"
@@ -582,6 +584,27 @@ void CDisplayWindow::slotSearchInModules() {
 void CDisplayWindow::printAll() {
     m_displayWidget->connectionsProxy()->printAll( m_displayOptions, m_filterOptions);
 }
+
+void CDisplayWindow::zoomIn_aleluya() {
+    BtHtmlReadDisplay* disp_aleluya = dynamic_cast<BtHtmlReadDisplay*>(displayWidget());
+    if (disp_aleluya) {
+        disp_aleluya->setZoomFactor(disp_aleluya->zoomFactor()*2);
+    }
+}
+
+void CDisplayWindow::zoomOut_aleluya() {
+    BtHtmlReadDisplay* disp_aleluya = dynamic_cast<BtHtmlReadDisplay*>(displayWidget());
+    if (disp_aleluya) {
+        disp_aleluya->setZoomFactor(disp_aleluya->zoomFactor()/2);
+    }
+}
+void CDisplayWindow::zoomReset_aleluya() {
+    BtHtmlReadDisplay* disp_aleluya = dynamic_cast<BtHtmlReadDisplay*>(displayWidget());
+    if (disp_aleluya) {
+        disp_aleluya->setZoomFactor(1);
+    }
+}
+
 
 void CDisplayWindow::printAnchorWithText() {
     m_displayWidget->connectionsProxy()->printAnchorWithText( m_displayOptions, m_filterOptions);

--- a/src/frontend/displaywindow/cdisplaywindow.h
+++ b/src/frontend/displaywindow/cdisplaywindow.h
@@ -311,6 +311,10 @@ class CDisplayWindow : public QMainWindow {
 
         void printAll();
 
+        void zoomOut_aleluya();
+        void zoomIn_aleluya();
+        void zoomReset_aleluya(); //✝ Aleluya!
+
         void printAnchorWithText();
 
         void setFocusKeyChooser();

--- a/src/frontend/displaywindow/clexiconreadwindow.cpp
+++ b/src/frontend/displaywindow/clexiconreadwindow.cpp
@@ -72,6 +72,15 @@ void CLexiconReadWindow::insertKeyboardActions( BtActionCollection* const a ) {
     qaction = new QAction(tr("Entry with text"), a);
     a->addAction("printEntryWithText", qaction);
 
+    qaction = new QAction(tr("Zoom Out"), a);
+    a->addAction("zoomOut", qaction);
+
+    qaction = new QAction(tr("Zoom In"), a);
+    a->addAction("zoomIn", qaction);
+
+    qaction = new QAction(tr("Zoom Reset"), a); //✝ Praise God in Jesus Holy name
+    a->addAction("zoomReset", qaction);
+
     qaction = new QAction( /* QIcon(CResMgr::displaywindows::general::findStrongs::icon), */ tr("Strong's Search"), a);
     qaction->setShortcut(CResMgr::displaywindows::general::findStrongs::accel);
     a->addAction(CResMgr::displaywindows::general::findStrongs::actionName, qaction);
@@ -132,6 +141,18 @@ void CLexiconReadWindow::initActions() {
     m_actions.print.entry = &initAction("printEntryWithText",
                                         this,
                                         &CLexiconReadWindow::printAll);
+
+    m_actions.zoom_aleluya.zoomIn_aleluya = &initAction("zoomIn",
+                                                        this,
+                                                        &CLexiconReadWindow::zoomIn_aleluya);
+
+    m_actions.zoom_aleluya.zoomOut_aleluya = &initAction("zoomOut",
+                                                        this,
+                                                        &CLexiconReadWindow::zoomOut_aleluya);
+
+    m_actions.zoom_aleluya.zoomReset_aleluya = &initAction("zoomReset",
+                                                        this,
+                                                        &CLexiconReadWindow::zoomReset_aleluya);
 
     // init with the user defined settings
     ac->readShortcuts("Lexicon shortcuts");
@@ -270,7 +291,18 @@ void CLexiconReadWindow::setupPopupMenu() {
     );
     m_actions.printMenu->addAction(m_actions.print.reference);
     m_actions.printMenu->addAction(m_actions.print.entry);
+
+
     popup()->addMenu(m_actions.printMenu);
+
+    m_actions.zoomMenu_aleluya = new QMenu(
+        tr("Zoom..."),
+        popup()
+    );
+    popup()->addMenu(m_actions.zoomMenu_aleluya);
+    m_actions.zoomMenu_aleluya->addAction(m_actions.zoom_aleluya.zoomIn_aleluya);
+    m_actions.zoomMenu_aleluya->addAction(m_actions.zoom_aleluya.zoomOut_aleluya);
+    m_actions.zoomMenu_aleluya->addAction(m_actions.zoom_aleluya.zoomReset_aleluya);
 }
 
 /** Reimplemented. */

--- a/src/frontend/displaywindow/clexiconreadwindow.h
+++ b/src/frontend/displaywindow/clexiconreadwindow.h
@@ -99,6 +99,14 @@ class CLexiconReadWindow : public CReadWindow  {
                 QAction* entry;
             }
             print;
+
+            QMenu* zoomMenu_aleluya;
+            struct {
+                QAction *zoomIn_aleluya;
+                QAction *zoomOut_aleluya;
+                QAction *zoomReset_aleluya;
+            }
+            zoom_aleluya;
         }
         m_actions;
 


### PR DESCRIPTION
…n Display

✝ I wanted to be able to zoom out on large images and maps. This is my first time working
on a Qt project communally thanks. I code with _aleluya added to variables/etc...
It reminds me and hopefully others to praise Jesus. He gives the talent to code.

The zoomer right now is simple, only doing a *2 or /2 and reset to 1 by using the
zoomFactor of QWebView, the method of accessing this functionality is understood
to be ok, as it was used from the raw html functions available.

I am not sure of any consequences yet of the HTML web engine functionality.
Plans include: add to Bible view, spanish and other translations, add finer
grained zoom, perhaps toolbar buttons and zoom around where mouse is centered,
use CTRL-mousewheel to zoom. I am not sure i will finish this as the main
functionality i want is there but God willing i will.

God guide us and bless you in Jesus Holy name