### PR TITLE
backend: Fix Bible boundaries

### DIFF
--- a/src/backend/drivers/cswordbiblemoduleinfo.cpp
+++ b/src/backend/drivers/cswordbiblemoduleinfo.cpp
@@ -41,19 +41,20 @@ void CSwordBibleModuleInfo::initBounds() const {
     const bool oldStatus = m.isSkipConsecutiveLinks();
     m.setSkipConsecutiveLinks(true);
 
+    sword::VerseKey const * const key =
+        static_cast<sword::VerseKey *>(m.getKey());
+    m_lowerBound.setVersification(key->getVersificationSystem());
+    m_upperBound.setVersification(key->getVersificationSystem());
+
     m.setPosition(sword::TOP); // position to first entry
-    sword::VerseKey key(m.getKeyText());
-    m_hasOT = (key.getTestament() == 1);
+    m_hasOT = (key->getTestament() == 1);
+    m_lowerBound.setKey(key->getText());
 
     m.setPosition(sword::BOTTOM);
-    key = m.getKeyText();
-    m_hasNT = (key.getTestament() == 2);
+    m_hasNT = (key->getTestament() == 2);
+    m_upperBound.setKey(key->getText());
 
     m.setSkipConsecutiveLinks(oldStatus);
-
-    m_lowerBound.setKey(m_hasOT ? "Genesis 1:1" : "Matthew 1:1");
-    m_upperBound.setKey(!m_hasNT ? "Malachi 4:6" : "Revelation of John 22:21");
-
     m_boundsInitialized = true;
 }
 
@@ -72,32 +73,14 @@ QStringList const & CSwordBibleModuleInfo::books() const {
     if (!m_bookList) {
         m_bookList.emplace();
 
-        // Initialize m_hasOT and m_hasNT
         if (!m_boundsInitialized)
             initBounds();
 
-        int min = 1; // 1 = OT
-        int max = 2; // 2 = NT
-
-        if (!m_hasOT)
-            min++; // min == 2
-
-        if (!m_hasNT)
-            max--; // max == 1
-
-        if (min > max) {
-            qWarning("CSwordBibleModuleInfo (%s) no OT and not NT! Check your "
-                     "config!",
-                     swordModule().getName());
-        } else {
-            std::unique_ptr<sword::VerseKey> key(
-                    static_cast<sword::VerseKey *>(swordModule().createKey()));
-            key->setPosition(sword::TOP);
-
-            for (key->setTestament(min); !key->popError() && key->getTestament() <= max; key->setBook(key->getBook() + 1)) {
-                m_bookList->append( QString::fromUtf8(key->getBookName()) );
-            }
-        }
+        CSwordVerseKey key(m_lowerBound);
+        do {
+            m_bookList->append(key.bookName());
+        } while (key.next(CSwordVerseKey::JumpType::UseBook) &&
+                 key <= m_upperBound);
     }
 
     return *m_bookList;

--- a/src/backend/keys/cswordversekey.h
+++ b/src/backend/keys/cswordversekey.h
@@ -159,6 +159,12 @@ class CSwordVerseKey final : public CSwordKey {
         long index() const { return m_key.getIndex(); }
         void setIndex(long v) { m_key.setIndex(v); }
         void positionToTop() { m_key.setPosition(sword::TOP); }
+        QString versification() const {
+            return m_key.getVersificationSystem();
+        }
+        void setVersification(const char * name) {
+            m_key.setVersificationSystem(name);
+        }
 
     protected:
 

--- a/src/backend/models/btmoduletextmodel.cpp
+++ b/src/backend/models/btmoduletextmodel.cpp
@@ -89,11 +89,10 @@ void BtModuleTextModel::reloadModules() {
     beginResetModel();
     const CSwordModuleInfo* firstModule = m_moduleInfoList.at(0);
     if (isBible() || isCommentary()) {
-        auto & m = firstModule->swordModule();
-        m.setPosition(sword::TOP);
-        m_firstEntry = m.getIndex();
-        m.setPosition(sword::BOTTOM);
-        m_maxEntries = m.getIndex() - m_firstEntry + 1;
+        CSwordBibleModuleInfo const * const m =
+            static_cast<const CSwordBibleModuleInfo *>(firstModule);
+        m_firstEntry = m->lowerBound().index();
+        m_maxEntries = m->upperBound().index() - m_firstEntry + 1;
     } else if(isLexicon()) {
         m_maxEntries =
                 static_cast<CSwordLexiconModuleInfo const *>(firstModule)


### PR DESCRIPTION
Fix both book list and text view boundaries for non complete Bibles:
![bibletime_fpYCPdbQuO](https://user-images.githubusercontent.com/638393/148442660-0e8fe5b5-e0d6-470f-b4eb-5766ec11cc73.png)
