### PR TITLE
Wip/kalemas/verse fix alignment

### DIFF
--- a/src/frontend/display/modelview/ColumnItem.qml
+++ b/src/frontend/display/modelview/ColumnItem.qml
@@ -97,7 +97,7 @@ Item {
     TextEdit {
         id: columnText
 
-        anchors.bottom: parent.bottom
+        anchors.top: columnTitle.visible ? columnTitle.bottom : parent.top
         anchors.left: columnView.left
         color: columnView.textColor
         font: columnView.font


### PR DESCRIPTION
This fixes verse text alignment in parallel views that is little confusing now:
![image](https://user-images.githubusercontent.com/638393/148462501-7cf65b71-635b-407d-99fc-091b615dd06b.png)

with this change top lines are always aligned:
![image](https://user-images.githubusercontent.com/638393/148462526-bbcaf7ea-d5c7-45d7-a71c-e2e13e9403de.png)