### PR TITLE
macos: suppress switch to discrete GPU

### DIFF
--- a/cmake/platforms/macos/Info.plist
+++ b/cmake/platforms/macos/Info.plist
@@ -20,5 +20,7 @@
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>
     <string>True</string>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Bibletime works just fine with the integrated GPU, which also
uses lower power. Without this addition, MacOS switches to the
discrete GPU, which drains battery faster.