### PR TITLE
Set the app's desktop file name

### DIFF
--- a/src/frontend/main.cpp
+++ b/src/frontend/main.cpp
@@ -190,6 +190,8 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
     }
 
+    QGuiApplication::setDesktopFileName("info.bibletime.BibleTime");
+
     app.startInit();
     if (!app.initBtConfig()) {
         return EXIT_FAILURE;


### PR DESCRIPTION
Set the desktop file name for the application using [QGuiApplication::setDesktopFileName](https://doc.qt.io/qt-6/qguiapplication.html#desktopFileName-prop). This is used by window managers/Wayland compositors like KWin to display the proper window icon on Wayland rather than a generic Wayland icon, as the icon is specified in the desktop file.

Screenshot of the application Window on KDE Plasma Wayland (Debian testing) without this PR in place:

![2024-04-27_screenshot_bibletime_master_generic_wayland_icon](https://github.com/bibletime/bibletime/assets/6560939/26094e2d-060f-49a7-a7fa-ea2fb7753469)


Screenshot with the PR in place:

![2024-04-27_screenshot_bibletime_proper_icon_wayland](https://github.com/bibletime/bibletime/assets/6560939/46115185-8050-42cb-b423-0ba808af8e98)

This matches the icon shown when run in an X11 session or explicitly forcing to run on XWayland by setting environment variable  `QT_QPA_PLATFORM=xcb`.