### PR TITLE
cmake: Set minimum required version first

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-PROJECT(bibletime CXX)
 CMAKE_MINIMUM_REQUIRED(VERSION 3.12)
+PROJECT(bibletime CXX)
 
 
 ######################################################


### PR DESCRIPTION
This addresses this CMake warning:

    CMake Warning (dev) at CMakeLists.txt:1 (PROJECT):
      cmake_minimum_required() should be called prior to this top-level project()
      call.  Please see the cmake-commands(7) manual for usage documentation of
      both commands.
    This warning is for project developers.  Use -Wno-dev to suppress it.

Quoting from the cmake-commands man page mentioned in the above warning:

> cmake_minimum_required
>     Require a minimum version of cmake.
>
>     [...]
>
>     NOTE:
>        Call  the  cmake_minimum_required() command at the beginning
>        of the top-level CMakeLists.txt file even before calling the
>        project() command.  It is important to establish version and
>        policy settings before invoking other commands whose behavior
>        they may affect.  See also policy CMP0000.