### PR TITLE
Drop obsolete note that compiling with Qt 6 doesn't work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ CMAKE_POLICY(SET CMP0028 NEW)
 #
 SET(USE_QT6 "OFF" CACHE BOOL
     "Whether to build with Qt6 instead of Qt5.")
-#NOTE: BibleTime will not compile with Qt6 yet.
 
 SET(BUILD_BIBLETIME "ON" CACHE BOOL
     "Whether to build and install the BibleTime application")


### PR DESCRIPTION
Building with Qt 6 using the `-DUSE_QT6=ON` CMake flag works fine by now, so drop the note saying it doesn't.