### PR TITLE
Use lupdate and lrelease from build-time Qt version, address various lupdate warnings

### DIFF
--- a/cmake/BTUITranslation.cmake
+++ b/cmake/BTUITranslation.cmake
@@ -2,25 +2,8 @@ SET(TS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/i18n/messages")
 SET(TS_PREFIX "bibletime_ui_")
 FILE(GLOB TS_FILES CONFIGURE_DEPENDS "${TS_DIR}/${TS_PREFIX}*.ts")
 
-IF(LinguistTools_FOUND)
-    GET_TARGET_PROPERTY(QT_LUPDATE_EXECUTABLE Qt::lupdate IMPORTED_LOCATION)
-    GET_TARGET_PROPERTY(QT_LRELEASE_EXECUTABLE Qt::lrelease IMPORTED_LOCATION)
-ELSE()
-    FIND_PROGRAM(QT_LUPDATE_EXECUTABLE lupdate
-        PATHS
-            /usr/bin/
-            /usr/lib/qt5/bin/
-            /usr/lib64/qt5/bin/
-            /usr/lib/x86_64-linux-gnu/qt5/bin/
-    )
-    FIND_PROGRAM(QT_LRELEASE_EXECUTABLE lrelease
-        PATHS
-            /usr/bin/
-            /usr/lib/qt5/bin/
-            /usr/lib64/qt5/bin/
-            /usr/lib/x86_64-linux-gnu/qt5/bin/
-    )
-ENDIF()
+GET_TARGET_PROPERTY(QT_LUPDATE_EXECUTABLE Qt::lupdate IMPORTED_LOCATION)
+GET_TARGET_PROPERTY(QT_LRELEASE_EXECUTABLE Qt::lrelease IMPORTED_LOCATION)
 
 # Update source catalog files (this is the basis for the translator's work)
 # Invoke this with "make messages"

--- a/src/frontend/bibletime_init.cpp
+++ b/src/frontend/bibletime_init.cpp
@@ -546,12 +546,12 @@ void BibleTime::initActions() {
             &m_actionCollection->action(QStringLiteral("autoTabbed"));
     m_windowAutoTabbedAction->setCheckable(true);
 
-    //: Vertical tiling means that windows are vertical, placed side by side
+    // Vertical tiling means that windows are vertical, placed side by side
     m_windowAutoTileVerticalAction =
             &m_actionCollection->action(QStringLiteral("autoVertical"));
     m_windowAutoTileVerticalAction->setCheckable(true);
 
-    //: Horizontal tiling means that windows are horizontal, placed on top of each other
+    // Horizontal tiling means that windows are horizontal, placed on top of each other
     m_windowAutoTileHorizontalAction =
             &m_actionCollection->action(QStringLiteral("autoHorizontal"));
     m_windowAutoTileHorizontalAction->setCheckable(true);

--- a/src/frontend/bibletime_slots.cpp
+++ b/src/frontend/bibletime_slots.cpp
@@ -63,7 +63,7 @@ public: // methods:
     }
 
     void retranslateUi()
-    { setWindowTitle(tr("What's this widget?")); }
+    { setWindowTitle(QCoreApplication::translate("DebugWindow", "What's this widget?")); }
 
     void timerEvent(QTimerEvent * const event) override {
         if (event->timerId() == m_updateTimerId) {
@@ -81,18 +81,19 @@ public: // methods:
                     if (!objectHierarchy.isEmpty()) {
                         objectHierarchy
                                 .append(QStringLiteral("<br/>"))
-                                .append(tr("<b>child of:</b> %1").arg(
+                                .append(QCoreApplication::translate("DebugWindow",
+                                            "<b>child of:</b> %1").arg(
                                             classHierarchy));
                     } else {
                         objectHierarchy.append(
-                                    tr("<b>This widget is:</b> %1").arg(
+                            QCoreApplication::translate("DebugWindow","<b>This widget is:</b> %1").arg(
                                         classHierarchy));
                     }
                     w = w->parent();
                 } while (w);
                 setHtml(objectHierarchy);
             } else {
-                setText(tr("No widget"));
+                setText(QCoreApplication::translate("DebugWindow", "No widget"));
             }
         } else {
             QTextEdit::timerEvent(event);

--- a/src/frontend/bookshelfwizard/cswordsetupinstallsourcesdialog.cpp
+++ b/src/frontend/bookshelfwizard/cswordsetupinstallsourcesdialog.cpp
@@ -40,12 +40,6 @@
 #include <swbuf.h>
 
 
-namespace {
-
-enum class SourceProtocol : int { Local, FTP, SFTP, HTTP, HTTPS };
-
-} // anonymous namespace
-
 CSwordSetupInstallSourcesDialog::CSwordSetupInstallSourcesDialog(/*QWidget *parent*/)
         : QDialog(),
         m_remoteListAdded(false) {

--- a/src/frontend/bookshelfwizard/cswordsetupinstallsourcesdialog.h
+++ b/src/frontend/bookshelfwizard/cswordsetupinstallsourcesdialog.h
@@ -39,3 +39,7 @@ class CSwordSetupInstallSourcesDialog final: public QDialog  {
         QComboBox *m_protocolCombo;
         bool m_remoteListAdded;
 };
+
+// enum defined here instead of in src/frontend/bookshelfwizard/cswordsetupinstallsourcesdialog.cpp
+// to work around Qt 6 lupdate bug https://bugreports.qt.io/browse/QTBUG-128904
+enum class SourceProtocol : int { Local, FTP, SFTP, HTTP, HTTPS };

--- a/src/frontend/displaywindow/clexiconreadwindow.h
+++ b/src/frontend/displaywindow/clexiconreadwindow.h
@@ -26,6 +26,8 @@ class CSwordModuleInfo;
 /** \brief The class used to display lexicons. */
 class CLexiconReadWindow: public CDisplayWindow {
 
+    Q_OBJECT
+
 public: // methods:
 
     CLexiconReadWindow(QList<CSwordModuleInfo *> const & modules,


### PR DESCRIPTION
This PR implements the following:

* Fix various lupdate warnings
* Make the build use lupdate and lrelease from the build-time Qt version instead of always the Qt 5 ones (reported in https://github.com/bibletime/bibletime/pull/474#issuecomment-2335537987 )
* Add a workaround for a bug encountered with Qt 6 lupdate (newly reported as https://bugreports.qt.io/browse/QTBUG-128904 )

The individual commits contain more detailed information.