### PR TITLE
Use QList instead of QVector

### DIFF
--- a/src/frontend/searchdialog/analysis/csearchanalysisitem.h
+++ b/src/frontend/searchdialog/analysis/csearchanalysisitem.h
@@ -15,9 +15,9 @@
 #include <QGraphicsRectItem>
 
 #include <cstddef>
+#include <QList>
 #include <QPixmap>
 #include <QString>
-#include <QVector>
 #include <memory>
 
 
@@ -45,7 +45,7 @@ class CSearchAnalysisItem : public QGraphicsRectItem {
     private: // fields:
         double m_scaleFactor = 0.0;
         QString const m_bookName;
-        QVector<std::size_t> m_counts;
+        QList<std::size_t> m_counts;
         std::unique_ptr<QPixmap> m_bufferPixmap;
 
 };

--- a/src/frontend/searchdialog/analysis/csearchanalysisscene.cpp
+++ b/src/frontend/searchdialog/analysis/csearchanalysisscene.cpp
@@ -18,7 +18,6 @@
 #include <QMap>
 #include <QTextStream>
 #include <QTextDocument>
-#include <QVector>
 #include <type_traits>
 #include <utility>
 #include "../../../backend/drivers/cswordmoduleinfo.h"

--- a/src/frontend/settingsdialogs/cdisplaysettings.cpp
+++ b/src/frontend/settingsdialogs/cdisplaysettings.cpp
@@ -147,7 +147,7 @@ void CDisplaySettingsPage::retranslateUi() {
 }
 
 void CDisplaySettingsPage::resetLanguage() {
-    QVector<QString> atv = bookNameAbbreviationsTryVector();
+    QList<QString> atv = bookNameAbbreviationsTryVector();
 
     BT_ASSERT(!atv.isEmpty());
     QString best = atv.takeLast();
@@ -167,8 +167,8 @@ void CDisplaySettingsPage::resetLanguage() {
     btConfig().setValue(QStringLiteral("GUI/booknameLanguage"), best);
 }
 
-QVector<QString> CDisplaySettingsPage::bookNameAbbreviationsTryVector() {
-    QVector<QString> atv;
+QList<QString> CDisplaySettingsPage::bookNameAbbreviationsTryVector() {
+    QList<QString> atv;
     atv.reserve(4);
     {
         QString settingsLanguage = btConfig().booknameLanguage();
@@ -209,7 +209,7 @@ void CDisplaySettingsPage::initSwordLocaleCombo() {
     }
 
     int index = 0;
-    QVector<QString> atv = bookNameAbbreviationsTryVector();
+    QList<QString> atv = bookNameAbbreviationsTryVector();
     for (auto it = languageNames.constBegin(); it != languageNames.constEnd(); ++it) {
         if (!atv.isEmpty()) {
             int i = atv.indexOf(it.value());

--- a/src/frontend/settingsdialogs/cdisplaysettings.h
+++ b/src/frontend/settingsdialogs/cdisplaysettings.h
@@ -14,9 +14,9 @@
 
 #include "btconfigdialog.h"
 
+#include <QList>
 #include <QObject>
 #include <QString>
-#include <QVector>
 
 
 class CConfigurationDialog;
@@ -46,7 +46,7 @@ class CDisplaySettingsPage: public BtConfigDialog::Page {
 
     private: // methods:
 
-        static QVector<QString> bookNameAbbreviationsTryVector();
+        static QList<QString> bookNameAbbreviationsTryVector();
         void initSwordLocaleCombo();
 
     private: // fields:


### PR DESCRIPTION
In Qt 6, QVector is just an alias for QList (see [1]).

Therefore, use QList directly, now that Qt 5 support was dropped in

    commit 81ad164001aa8ba9b0c58be88c99076b20130b5f
    Date:   Tue Feb 25 20:30:15 2025 +0200

        Drop support for Qt5

[1] https://doc.qt.io/qt-6/qvector.html