### PR TITLE
Two column Bible books drop-down

### DIFF
--- a/src/frontend/keychooser/versekeychooser/btbiblekeywidget.cpp
+++ b/src/frontend/keychooser/versekeychooser/btbiblekeywidget.cpp
@@ -30,6 +30,7 @@
 #include "../../../util/cresmgr.h"
 #include "../cscrollerwidgetset.h"
 #include "btdropdownchooserbutton.h"
+#include "btbookchooserbutton.h"
 
 
 class BtLineEdit : public QLineEdit {
@@ -125,21 +126,18 @@ BtBibleKeyWidget::BtBibleKeyWidget(
     m_dropDownButtons->setCursor(Qt::ArrowCursor);
     QHBoxLayout *dropDownButtonsLayout(new QHBoxLayout(m_dropDownButtons));
 
-    auto * const bookChooser =
-            new BtDropdownChooserButton(&BtBibleKeyWidget::populateBookMenu,
-                                        *this);
+    auto * const bookChooser = new BtBookChooserButton(*this);
     bookChooser->setToolTip(tr("Select book"));
-    BT_CONNECT(bookChooser->menu(), &QMenu::triggered,
-               [this](QAction * const action) {
-                    auto bookname = action->property("bookname").toString();
+    BT_CONNECT(bookChooser, &BtBookChooserButton::bookSelected,
+               [this](const QString & bookname) {
                     if (m_key->bookName() != bookname) {
-                        m_key->setBookName(std::move(bookname));
+                        m_key->setBookName(bookname);
                         updateText();
                     }
                     if (!updatelock)
                         Q_EMIT changed(m_key);
                });
-    BT_CONNECT(bookChooser, &BtDropdownChooserButton::stepItem, slotStepBook);
+    BT_CONNECT(bookChooser, &BtBookChooserButton::stepItem, slotStepBook);
     dropDownButtonsLayout->addWidget(bookChooser, 2);
 
     auto * const chapterChooser =

--- a/src/frontend/keychooser/versekeychooser/btbiblekeywidget.h
+++ b/src/frontend/keychooser/versekeychooser/btbiblekeywidget.h
@@ -35,6 +35,8 @@ class BtBibleKeyWidget : public QWidget  {
         void setModule(const CSwordBibleModuleInfo *m = nullptr);
         bool eventFilter(QObject *o, QEvent *e) override;
 
+        const CSwordBibleModuleInfo* module() const { return m_module; }
+
     Q_SIGNALS:
         void changed(CSwordVerseKey* key);
 

--- a/src/frontend/keychooser/versekeychooser/btbookchooserbutton.cpp
+++ b/src/frontend/keychooser/versekeychooser/btbookchooserbutton.cpp
@@ -1,0 +1,177 @@
+/*********
+*
+* In the name of the Father, and of the Son, and of the Holy Spirit.
+*
+* This file is part of BibleTime's source code, https://bibletime.info/
+*
+* Copyright 1999-2025 by the BibleTime developers.
+* The BibleTime source code is licensed under the GNU General Public License
+* version 2.0.
+*
+**********/
+
+#include "btbookchooserbutton.h"
+#include "btbiblekeywidget.h"
+
+#include <QApplication>
+#include <QScreen>
+#include <QFocusEvent>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QWheelEvent>
+#include <QMenu>
+#include <QWidgetAction>
+
+const unsigned int ARROW_HEIGHT = 15;
+
+// BtTwoColumnBookWidget - Widget for displaying books in two columns within a QMenu
+class BtTwoColumnBookWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit BtTwoColumnBookWidget(const QStringList& books, QWidget* parent = nullptr)
+        : QWidget(parent)
+    {
+        setupLayout(books);
+    }
+
+Q_SIGNALS:
+    void bookSelected(const QString& bookName);
+
+private Q_SLOTS:
+    void onBookButtonClicked() {
+        if (QPushButton* button = qobject_cast<QPushButton*>(sender())) {
+            QString bookName = button->text();
+            Q_EMIT bookSelected(bookName);
+        }
+    }
+
+private:
+    void setupLayout(const QStringList& books) {
+        // Main horizontal layout for two columns
+        QHBoxLayout* mainLayout = new QHBoxLayout(this);
+        mainLayout->setContentsMargins(8, 8, 8, 8);
+        mainLayout->setSpacing(12);
+        
+        // Left and right column layouts
+        QVBoxLayout* leftColumn = new QVBoxLayout();
+        QVBoxLayout* rightColumn = new QVBoxLayout();
+        leftColumn->setSpacing(2);
+        rightColumn->setSpacing(2);
+        leftColumn->setAlignment(Qt::AlignTop);
+        rightColumn->setAlignment(Qt::AlignTop);
+        
+        // Distribute books between columns
+        int totalBooks = books.size();
+        int booksPerColumn = (totalBooks + 1) / 2; // Round up for left column
+        
+        for (int i = 0; i < totalBooks; ++i) {
+            QPushButton* button = new QPushButton(books[i], this);
+            button->setFlat(true);
+            button->setStyleSheet(
+                "QPushButton {"
+                "   text-align: left;"
+                "   padding: 0 12px;"
+                "   border: 1px solid transparent;"
+                "   background: transparent;"
+                "   min-width: 120px;"
+                "   min-height: 24px;"
+                "}"
+                "QPushButton:hover {"
+                "   background-color: rgba(128,128,128,0.1);"
+                "}"
+            );
+            
+            connect(button, &QPushButton::clicked, this, &BtTwoColumnBookWidget::onBookButtonClicked);
+            
+            // Add to left column for first half, right column for remainder
+            if (i < booksPerColumn) {
+                leftColumn->addWidget(button);
+            } else {
+                rightColumn->addWidget(button);
+            }
+        }
+        
+        mainLayout->addLayout(leftColumn, 1);
+        mainLayout->addLayout(rightColumn, 1);
+        
+        // Set reasonable size
+        setMinimumSize(300, 400);
+        setMaximumSize(500, 600);
+    }
+};
+
+// BtBookChooserButton implementation
+BtBookChooserButton::BtBookChooserButton(BtBibleKeyWidget& parent)
+    : QToolButton(&parent)
+    , m_parent(parent)
+    , m_menu(nullptr)
+{
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    setAutoRaise(false);
+    setArrowType(Qt::NoArrow);
+    setFixedHeight(ARROW_HEIGHT);
+    setFocusPolicy(Qt::NoFocus);
+    setStyleSheet(
+        "QToolButton{margin:0px;}"
+        "QToolButton::menu-indicator{"
+        "   subcontrol-position:center center"
+        "}"
+    );
+    
+    // Create the menu
+    m_menu = new QMenu(this);
+    setMenu(m_menu);
+    setPopupMode(QToolButton::InstantPopup);
+    
+    // Connect to populate menu when it's about to show
+    connect(m_menu, &QMenu::aboutToShow, this, &BtBookChooserButton::populateMenu);
+}
+
+void BtBookChooserButton::populateMenu() {
+    // Clear existing menu items
+    m_menu->clear();
+    
+    // Get books from parent module
+    if (!m_parent.module()) {
+        return;
+    }
+    
+    QStringList books = m_parent.module()->books();
+    if (books.isEmpty()) {
+        return;
+    }
+    
+    // Create the two-column widget
+    BtTwoColumnBookWidget* bookWidget = new BtTwoColumnBookWidget(books, m_menu);
+    
+    // Connect the book selection signal
+    connect(bookWidget, &BtTwoColumnBookWidget::bookSelected, 
+            this, &BtBookChooserButton::onBookSelected);
+    
+    // Create a QWidgetAction to hold our custom widget
+    QWidgetAction* widgetAction = new QWidgetAction(m_menu);
+    widgetAction->setDefaultWidget(bookWidget);
+    m_menu->addAction(widgetAction);
+}
+
+void BtBookChooserButton::onBookSelected(const QString& bookName) {
+    // Hide menu and emit signals
+    m_menu->hide();
+    Q_EMIT bookSelected(bookName);
+}
+
+void BtBookChooserButton::wheelEvent(QWheelEvent* e) {
+    int const delta = e->angleDelta().y();
+    if (delta == 0) {
+        e->ignore();
+    } else {
+        Q_EMIT stepItem((delta > 0) ? -1 : 1);
+        e->accept();
+    }
+}
+
+#include "btbookchooserbutton.moc"

--- a/src/frontend/keychooser/versekeychooser/btbookchooserbutton.cpp
+++ b/src/frontend/keychooser/versekeychooser/btbookchooserbutton.cpp
@@ -100,7 +100,7 @@ private:
         
         // Set reasonable size
         setMinimumSize(300, 400);
-        setMaximumSize(500, 600);
+        setMaximumSize(600, 800);
     }
 };
 

--- a/src/frontend/keychooser/versekeychooser/btbookchooserbutton.h
+++ b/src/frontend/keychooser/versekeychooser/btbookchooserbutton.h
@@ -1,0 +1,44 @@
+/*********
+*
+* In the name of the Father, and of the Son, and of the Holy Spirit.
+*
+* This file is part of BibleTime's source code, https://bibletime.info/
+*
+* Copyright 1999-2025 by the BibleTime developers.
+* The BibleTime source code is licensed under the GNU General Public License
+* version 2.0.
+*
+**********/
+
+#pragma once
+
+#include <QToolButton>
+#include <QObject>
+
+class BtBibleKeyWidget;
+class QMenu;
+
+/**
+* Specialized dropdown button for book selection with two-column layout using native QMenu.
+*/
+class BtBookChooserButton : public QToolButton {
+    Q_OBJECT
+
+public:
+    BtBookChooserButton(BtBibleKeyWidget& parent);
+
+protected:
+    void wheelEvent(QWheelEvent* event) override;
+
+Q_SIGNALS:
+    void stepItem(int step);
+    void bookSelected(const QString& bookName);
+
+private Q_SLOTS:
+    void populateMenu();
+    void onBookSelected(const QString& bookName);
+
+private:
+    BtBibleKeyWidget& m_parent;
+    QMenu* m_menu;
+};


### PR DESCRIPTION
I offer this for your consideration, as a means of addressing issue https://github.com/bibletime/bibletime/issues/476.

<img width="1175" height="1044" alt="image" src="https://github.com/user-attachments/assets/f31cbe63-4d88-4527-8052-b68e1684a61f" />


Issue https://github.com/bibletime/bibletime/issues/476 has made it difficult to quickly access the book of Genesis in particular, as it may be clipped off the top of the screen on some displays.  I've had to resort to going to Exodus, then scrolling up to access Genesis.  This pull request seeks to address this issue by creating a two-column drop-down menu for bible books.

My development environment I've built and tested this against is:
- Arch based Linux (6.15.9 x86_64)
- QT 6.9.1
- Sword 1.9.0
- CLucene 2.3.3.4
- CMake 4.0.3
- KDE Plasma (Wayland) 6.4.3