### PR TITLE
Raise CLucene minimum version to align with version specified in cmake/BTApplication.cmake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The following requirements are needed only if you want to develop BibleTime.
  - A C++17 compiler.
  - [Qt 6.7+](https://www.qt.io)
  - [Sword 1.8.1+](https://crosswire.org/sword) (built against ICU)
- - [CLucene 2.0+](https://clucene.sf.net)
+ - [CLucene 2.3.3.4+](https://clucene.sf.net)
  - [CMake 3.25+](https://cmake.org)
  - [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) (or
    [pkgconf](https://gitea.treehouse.systems/ariadne/pkgconf))


### PR DESCRIPTION
`cmake/BTApplication.cmake` currently specifies minimum version for CLucene as 2.3.3.4, which is inconsistent with `README.md`'s minimum version for CLucene, 2.0.

[`cmake/BTApplication.cmake`](https://github.com/bibletime/bibletime/blob/master/cmake/BTApplication.cmake#L20) 
```cmake
pkg_search_module(CLucene REQUIRED IMPORTED_TARGET libclucene-core>=2.3.3.4)
```

[`README.md`](https://github.com/bibletime/bibletime/blob/master/README.md)
```md
 - [CLucene 2.0+](https://clucene.sf.net)
```

This patch updates `README.md`, but alternatively limiting `cmake/BTApplication.cmake` to `libclucene-core>=2.0` would also suffice.