### PR TITLE
Qt minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The following requirements are needed only if you want to develop BibleTime.
 
 ### BUILD REQUIREMENTS
  - A C++17 compiler.
- - [Qt 6.7+](https://www.qt.io)
+ - [Qt 6.4+](https://www.qt.io)
  - [Sword 1.8.1+](https://crosswire.org/sword) (built against ICU)
  - [CLucene 2.0+](https://clucene.sf.net)
  - [CMake 3.25+](https://cmake.org)

--- a/cmake/BTApplication.cmake
+++ b/cmake/BTApplication.cmake
@@ -1,7 +1,7 @@
 ######################################################
 # Find packages:
 #
-FIND_PACKAGE(Qt6 6.7 REQUIRED COMPONENTS
+FIND_PACKAGE(Qt6 6.4 REQUIRED COMPONENTS
     Core
     Gui
     LinguistTools


### PR DESCRIPTION
There doesn't appear to be any advantage (I'm aware of) to raising the QT minimum requirement to 6.7+.  The codebase would seem to be QT 6.4 compatible.

This pull request modifies `README.md` and `cmake/BTApplication.cmake`, reducing the QT minimum version requirement to 6.4.