### PR TITLE
Implement focus location feature request (Issue #353)

### DIFF
--- a/src/frontend/displaywindow/cdisplaywindow.cpp
+++ b/src/frontend/displaywindow/cdisplaywindow.cpp
@@ -260,9 +260,9 @@ CDisplayWindow::CDisplayWindow(BtModuleList const & modules,
                             QStringLiteral("GUI/showToolbarsInEachWindow"),
                             true))
                     {
-                        m_keyChooser->setFocus();
+                        m_keyChooser->focusLocation();
                     } else if (auto * const kc = btMainWindow()->keyChooser()) {
-                        kc->setFocus();
+                        kc->focusLocation();
                     }
                 });
     initAddAction(QStringLiteral("pageDown"),

--- a/src/frontend/keychooser/cbookkeychooser.cpp
+++ b/src/frontend/keychooser/cbookkeychooser.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <QComboBox>
 #include <QHBoxLayout>
+#include <QLineEdit>
 #include <QStringList>
 #include <Qt>
 #include <QtAlgorithms>
@@ -260,4 +261,12 @@ void CBookKeyChooser::keyChooserChanged(int newIndex) {
 /** Updates the keychoosers for the given key but emit no signal. */
 void CBookKeyChooser::updateKey(CSwordKey * key) {
     setKey(key, false);
+}
+
+void CBookKeyChooser::focusLocation() {
+    BT_ASSERT(!m_chooserWidgets.isEmpty());
+    CKeyChooserWidget * const chooser = m_chooserWidgets.first();
+    BT_ASSERT(chooser);
+    chooser->setFocus();
+    chooser->comboBox().lineEdit()->selectAll();
 }

--- a/src/frontend/keychooser/cbookkeychooser.h
+++ b/src/frontend/keychooser/cbookkeychooser.h
@@ -53,6 +53,9 @@ public Q_SLOTS:
     /** \brief Updates the keychoosers for the given key but emit no signal. */
     void updateKey(CSwordKey * key) final override;
 
+    /** \brief Handles the focusLocation action.*/
+    void focusLocation() final override;
+
 protected: // methods:
 
     /**

--- a/src/frontend/keychooser/cbooktreechooser.cpp
+++ b/src/frontend/keychooser/cbooktreechooser.cpp
@@ -142,6 +142,10 @@ void CBookTreeChooser::updateKey( CSwordKey* key ) {
     setKey(key);
 }
 
+void CBookTreeChooser::focusLocation() {
+    m_treeView->setFocus();
+}
+
 /** Reimplementation to handle tree creation on show. */
 void CBookTreeChooser::showEvent(QShowEvent * const showEvent) {
     if (!m_treeView->topLevelItemCount()) {

--- a/src/frontend/keychooser/cbooktreechooser.h
+++ b/src/frontend/keychooser/cbooktreechooser.h
@@ -52,6 +52,8 @@ public Q_SLOTS:
 
     void updateKey(CSwordKey *) final override;
 
+    void focusLocation() final override;
+
 private: // methods:
 
     /** \brief Creates the first level of the tree structure. */

--- a/src/frontend/keychooser/ckeychooser.h
+++ b/src/frontend/keychooser/ckeychooser.h
@@ -74,6 +74,11 @@ public Q_SLOTS:
     */
     virtual void updateKey(CSwordKey * key) = 0;
 
+    /**
+      Sets keyboard focus to the location field.
+     */
+    virtual void focusLocation() = 0;
+
     void handleHistoryMoved(QString const & newKey);
 
 Q_SIGNALS:

--- a/src/frontend/keychooser/ckeychooserwidget.cpp
+++ b/src/frontend/keychooser/ckeychooserwidget.cpp
@@ -25,30 +25,11 @@
 #include "cscrollerwidgetset.h"
 
 
-class BtKeyLineEdit : public QLineEdit {
-
-public: // methods:
-
-    BtKeyLineEdit(QWidget * parent)
-        : QLineEdit(parent) {}
-
-protected: // methods:
-
-    void focusInEvent(QFocusEvent * event) override {
-        const Qt::FocusReason reason = event->reason();
-        if (reason == Qt::OtherFocusReason)
-            selectAll();
-        QWidget::focusInEvent(event);
-    }
-
-};
-
-
 CKCComboBox::CKCComboBox(QWidget * parent)
     : QComboBox(parent)
 {
     setFocusPolicy(Qt::WheelFocus);
-    setLineEdit(new BtKeyLineEdit(this));
+    setLineEdit(new QLineEdit(this));
     if (lineEdit())
         installEventFilter(lineEdit());
 }

--- a/src/frontend/keychooser/clexiconkeychooser.cpp
+++ b/src/frontend/keychooser/clexiconkeychooser.cpp
@@ -18,6 +18,7 @@
 #include <QBoxLayout>
 #include <QComboBox>
 #include <QHBoxLayout>
+#include <QLineEdit>
 #include <QLayout>
 #include <QStringList>
 #include <Qt>
@@ -95,6 +96,11 @@ void CLexiconKeyChooser::updateKey(CSwordKey* key) {
     QString newKey = m_key->key();
     const int index = m_widget->comboBox().findText(newKey);
     m_widget->comboBox().setCurrentIndex(index);
+}
+
+void CLexiconKeyChooser::focusLocation() {
+    m_widget->setFocus();
+    m_widget->comboBox().lineEdit()->selectAll();
 }
 
 void CLexiconKeyChooser::setKey(CSwordKey* key) {

--- a/src/frontend/keychooser/clexiconkeychooser.h
+++ b/src/frontend/keychooser/clexiconkeychooser.h
@@ -52,6 +52,8 @@ public Q_SLOTS:
 
     void updateKey(CSwordKey* key) final override;
 
+    void focusLocation() final override;
+
 private: // fields:
 
     CKeyChooserWidget * m_widget;

--- a/src/frontend/keychooser/versekeychooser/btbiblekeywidget.cpp
+++ b/src/frontend/keychooser/versekeychooser/btbiblekeywidget.cpp
@@ -32,23 +32,6 @@
 #include "btdropdownchooserbutton.h"
 
 
-class BtLineEdit : public QLineEdit {
-    public:
-        BtLineEdit(QWidget* parent)
-                : QLineEdit(parent) {
-        }
-    protected:
-        void focusInEvent(QFocusEvent* event) override {
-            Qt::FocusReason reason = event->reason();
-            if (reason == Qt::OtherFocusReason) {
-                selectAll();
-            }
-
-            QWidget::focusInEvent(event);
-        }
-};
-
-
 BtBibleKeyWidget::BtBibleKeyWidget(
         CSwordBibleModuleInfo const * mod,
         CSwordVerseKey * key,
@@ -100,7 +83,7 @@ BtBibleKeyWidget::BtBibleKeyWidget(
 
     auto * const bookScroller = new CScrollerWidgetSet(this);
 
-    m_textbox = new BtLineEdit( this );
+    m_textbox = new QLineEdit( this );
     setFocusProxy(m_textbox);
     m_textbox->setContentsMargins(0, 0, 0, 0);
 
@@ -266,6 +249,10 @@ bool BtBibleKeyWidget::eventFilter(QObject *o, QEvent *e) {
         default:
             return false;
     }
+}
+
+void BtBibleKeyWidget::selectAll() {
+    m_textbox->selectAll();
 }
 
 void BtBibleKeyWidget::enterEvent(QEnterEvent *) {

--- a/src/frontend/keychooser/versekeychooser/btbiblekeywidget.h
+++ b/src/frontend/keychooser/versekeychooser/btbiblekeywidget.h
@@ -34,6 +34,7 @@ class BtBibleKeyWidget : public QWidget  {
         bool setKey(CSwordVerseKey* key);
         void setModule(const CSwordBibleModuleInfo *m = nullptr);
         bool eventFilter(QObject *o, QEvent *e) override;
+        void selectAll();
 
     Q_SIGNALS:
         void changed(CSwordVerseKey* key);

--- a/src/frontend/keychooser/versekeychooser/cbiblekeychooser.cpp
+++ b/src/frontend/keychooser/versekeychooser/cbiblekeychooser.cpp
@@ -96,3 +96,8 @@ void CBibleKeyChooser::refreshContent() {
 void CBibleKeyChooser::updateKey(CSwordKey* /*key*/) {
     m_widget->updateText();
 }
+
+void CBibleKeyChooser::focusLocation() {
+    m_widget->setFocus();
+    m_widget->selectAll();
+}

--- a/src/frontend/keychooser/versekeychooser/cbiblekeychooser.h
+++ b/src/frontend/keychooser/versekeychooser/cbiblekeychooser.h
@@ -47,6 +47,8 @@ public Q_SLOTS:
 
     void updateKey(CSwordKey * key) final override;
 
+    void focusLocation() final override;
+
 private: // fields:
 
     BtBibleKeyWidget * m_widget = nullptr;


### PR DESCRIPTION
Dear Bibletime team,

I submit the following patch for consideration.

The action triggered by Ctrl+L was calling `setFocus` on the key chooser widget directly, meaning that if the key chooser already had focus it would not receive another focus event (and thus would not re-select its contents). With this patch the focus is set indirectly via a dedicated, virtual `focusLocation` slot added to `CKeyChooser`. Each derived key chooser then implements `focusLocation` as required.

This change also makes the private `BtKeyLineEdit` and `BtLineEdit` replaceable with standard `QLineEdit` instances, because those derived classes existed only for the purpose of overriding `QLineEdit::focusInEvent`.
