### PR TITLE
Improve find icon handling to remove multiple "WARNING: The requested buffer size is too big, ignoring" during startup

### DIFF
--- a/pics/icons/find.svg
+++ b/pics/icons/find.svg
@@ -1,2922 +1,347 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="128"
-   height="128"
-   id="svg2"
-   version="1.0">
-  <defs
-     id="defs4">
-    <linearGradient
-       id="linearGradient11200">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop11202" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop11204" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10959">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop10961" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop10963" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10267">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop10269" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop10271" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10231">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop10233" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop10235" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient9182">
-      <stop
-         style="stop-color:#3a3a3c;stop-opacity:1;"
-         offset="0"
-         id="stop9184" />
-      <stop
-         id="stop9190"
-         offset="0.5"
-         style="stop-color:#5d5d60;stop-opacity:1;" />
-      <stop
-         style="stop-color:#97989b;stop-opacity:1;"
-         offset="1"
-         id="stop9186" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient9015">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop9017" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop9019" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7974">
-      <stop
-         style="stop-color:#a04e21;stop-opacity:1;"
-         offset="0"
-         id="stop7976" />
-      <stop
-         style="stop-color:#a04e21;stop-opacity:0;"
-         offset="1"
-         id="stop7978" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7964">
-      <stop
-         style="stop-color:#fff0c3;stop-opacity:1;"
-         offset="0"
-         id="stop7966" />
-      <stop
-         style="stop-color:#c13d00;stop-opacity:0;"
-         offset="1"
-         id="stop7968" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7866">
-      <stop
-         style="stop-color:#f4bea0;stop-opacity:1;"
-         offset="0"
-         id="stop7868" />
-      <stop
-         style="stop-color:#e5702f;stop-opacity:0;"
-         offset="1"
-         id="stop7870" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7488">
-      <stop
-         style="stop-color:#eb7331;stop-opacity:1;"
-         offset="0"
-         id="stop7490" />
-      <stop
-         style="stop-color:#eb7331;stop-opacity:0;"
-         offset="1"
-         id="stop7492" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7402">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop7404" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop7406" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7384">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop7386" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop7388" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7272">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop7274" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop7276" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7029">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop7031" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop7033" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6981">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop6983" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop6985" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6202">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop6204" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop6206" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6060">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop6062" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop6064" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5991">
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="0"
-         id="stop5993" />
-      <stop
-         id="stop6001"
-         offset="0.25"
-         style="stop-color:#000000;stop-opacity:0.68327403;" />
-      <stop
-         id="stop5999"
-         offset="0.5"
-         style="stop-color:#000000;stop-opacity:1;" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0.72953737;"
-         offset="0.75"
-         id="stop6003" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop5995" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5925">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop5927" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop5929" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5811">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop5813" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop5815" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5761">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop5763" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop5765" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5626">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop5628" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop5630" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5595">
-      <stop
-         style="stop-color:#dddbdc;stop-opacity:1;"
-         offset="0"
-         id="stop5597" />
-      <stop
-         id="stop6560"
-         offset="0.74324322"
-         style="stop-color:#878485;stop-opacity:1;" />
-      <stop
-         style="stop-color:#4e4c4d;stop-opacity:1;"
-         offset="0.80916727"
-         id="stop6562" />
-      <stop
-         style="stop-color:#2e2c2d;stop-opacity:1;"
-         offset="1"
-         id="stop5599" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5315">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop5317" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop5319" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5027">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop5029" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop5031" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3709">
-      <stop
-         style="stop-color:#d3d7cf;stop-opacity:1;"
-         offset="0"
-         id="stop3711" />
-      <stop
-         style="stop-color:#d3d7cf;stop-opacity:0;"
-         offset="1"
-         id="stop3714" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3367">
-      <stop
-         style="stop-color:#2e3436;stop-opacity:1;"
-         offset="0"
-         id="stop3369" />
-      <stop
-         id="stop3385"
-         offset="0.25"
-         style="stop-color:#343a3c;stop-opacity:1;" />
-      <stop
-         id="stop3383"
-         offset="0.5"
-         style="stop-color:#839095;stop-opacity:1;" />
-      <stop
-         style="stop-color:#323739;stop-opacity:1;"
-         offset="0.75"
-         id="stop3387" />
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="1"
-         id="stop3371" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3709"
-       id="linearGradient3716"
-       x1="116.03014"
-       y1="173.43127"
-       x2="113.86565"
-       y2="159.77208"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       xlink:href="#linearGradient3367"
-       id="linearGradient3802"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0066365,0.4045235,0.375629,-0.9347339,63.723658,169.83093)"
-       x1="13.263171"
-       y1="108.2279"
-       x2="54.920765"
-       y2="82.326797" />
-    <linearGradient
-       xlink:href="#linearGradient3709"
-       id="linearGradient3935"
-       gradientUnits="userSpaceOnUse"
-       x1="116.03014"
-       y1="173.43127"
-       x2="113.86565"
-       y2="159.77208" />
-    <linearGradient
-       xlink:href="#linearGradient3709"
-       id="linearGradient3958"
-       gradientUnits="userSpaceOnUse"
-       x1="116.03014"
-       y1="173.43127"
-       x2="113.86565"
-       y2="159.77208" />
-    <radialGradient
-       xlink:href="#linearGradient5027"
-       id="radialGradient5286"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4800839,0,81.724319)"
-       cx="553"
-       cy="180.62091"
-       fx="553"
-       fy="180.62091"
-       r="29.8125" />
-    <radialGradient
-       xlink:href="#linearGradient5027"
-       id="radialGradient5288"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4800839,0,81.724319)"
-       cx="528.75"
-       cy="143.12746"
-       fx="528.75"
-       fy="143.12746"
-       r="29.8125" />
-    <radialGradient
-       xlink:href="#linearGradient5027"
-       id="radialGradient5292"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4800839,0,81.724319)"
-       cx="548.5"
-       cy="180.62091"
-       fx="548.5"
-       fy="180.62091"
-       r="29.8125" />
-    <linearGradient
-       xlink:href="#linearGradient5315"
-       id="linearGradient5321"
-       x1="544.61157"
-       y1="132.01134"
-       x2="551.56006"
-       y2="150.84375"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       xlink:href="#linearGradient5027"
-       id="radialGradient5438"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4800839,0,81.724319)"
-       cx="583.72137"
-       cy="157.18748"
-       fx="583.72137"
-       fy="157.18748"
-       r="29.8125" />
-    <radialGradient
-       xlink:href="#linearGradient5027"
-       id="radialGradient5440"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4800839,0,81.724319)"
-       cx="548.5"
-       cy="180.62091"
-       fx="548.5"
-       fy="180.62091"
-       r="29.8125" />
-    <linearGradient
-       xlink:href="#linearGradient5315"
-       id="linearGradient5444"
-       gradientUnits="userSpaceOnUse"
-       x1="563.72076"
-       y1="127.41514"
-       x2="551.56006"
-       y2="150.84375" />
-    <filter
-       id="filter5622">
-      <feGaussianBlur
-         stdDeviation="0.3713333"
-         id="feGaussianBlur5624" />
-    </filter>
-    <filter
-       id="filter5698">
-      <feGaussianBlur
-         stdDeviation="0.26202037"
-         id="feGaussianBlur5700" />
-    </filter>
-    <filter
-       id="filter5753">
-      <feGaussianBlur
-         stdDeviation="1.4374244"
-         id="feGaussianBlur5755" />
-    </filter>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath5757">
-      <path
-         id="path5759"
-         d="M 1165.6379,-265.85848 L 1179.78,-265.85848 C 1192.3013,-265.85848 1196.9141,-286.98626 1190.3773,-293.53287 L 1163.3837,-320.52644 C 1158.3031,-325.60705 1150.2775,-326.00936 1144.3808,-322.63358 C 1140.6996,-320.5262 1138.7021,-316.44603 1137.2432,-312.28434 C 1127.6736,-311.81484 1115.4849,-309.30301 1107.1405,-294.90456 L 1165.6379,-265.85848 z "
-         style="fill:#3d3b3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    </clipPath>
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient5767"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient5817"
-       x1="1044.3829"
-       y1="-328.56128"
-       x2="1029.3492"
-       y2="-323.61151"
-       gradientUnits="userSpaceOnUse" />
-    <filter
-       x="-0.11477411"
-       width="1.2295482"
-       y="-0.08688508"
-       height="1.1737702"
-       id="filter5911">
-      <feGaussianBlur
-         stdDeviation="0.87156593"
-         id="feGaussianBlur5913" />
-    </filter>
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient5921"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-317.5,0)"
-       x1="1320.7188"
-       y1="-304.53207"
-       x2="1380.5529"
-       y2="-304.53207" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath5917">
-      <path
-         id="path5919"
-         d="M 1054.4062,-343.21875 C 1051.7213,-343.25923 1049.0198,-342.55396 1046.6875,-341.21875 C 1043.3595,-339.31356 1041.5376,-335.63742 1040.2188,-331.875 C 1031.5672,-331.45053 1020.5439,-329.17333 1013,-316.15625 L 1003.3125,-295.21875 L 1003.4062,-295.21875 C 1003.3436,-295.11271 1003.2809,-295.01361 1003.2188,-294.90625 L 1061.7188,-265.84375 L 1075.8438,-265.84375 C 1083.6075,-265.84374 1088.3096,-273.98184 1089.2188,-281.71875 L 1089.25,-281.71875 L 1089.25,-281.90625 C 1089.2835,-282.21131 1089.291,-282.50939 1089.3125,-282.8125 L 1089.3438,-283.0625 C 1089.367,-283.44867 1089.4027,-283.83818 1089.4062,-284.21875 L 1090.75,-304.03125 C 1091.2971,-308.38183 1090.5296,-312.62325 1088.25,-314.90625 L 1063.8438,-339.3125 C 1061.2601,-341.89616 1057.8584,-343.1667 1054.4062,-343.21875 z "
-         style="fill:url(#linearGradient5921);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    </clipPath>
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient5931"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       gradientUnits="userSpaceOnUse" />
-    <filter
-       id="filter5977">
-      <feGaussianBlur
-         stdDeviation="0.27275091"
-         id="feGaussianBlur5979" />
-    </filter>
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient5987"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-317.5,0)"
-       x1="1320.7188"
-       y1="-304.53207"
-       x2="1380.5529"
-       y2="-304.53207" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath5983">
-      <path
-         id="path5985"
-         d="M 1054.4062,-343.21875 C 1051.7213,-343.25923 1049.0198,-342.55396 1046.6875,-341.21875 C 1043.3595,-339.31356 1041.5376,-335.63742 1040.2188,-331.875 C 1031.5672,-331.45053 1020.5439,-329.17333 1013,-316.15625 L 1003.3125,-295.21875 L 1003.4062,-295.21875 C 1003.3436,-295.11271 1003.2809,-295.01361 1003.2188,-294.90625 L 1061.7188,-265.84375 L 1075.8438,-265.84375 C 1083.6075,-265.84374 1088.3096,-273.98184 1089.2188,-281.71875 L 1089.25,-281.71875 L 1089.25,-281.90625 C 1089.2835,-282.21131 1089.291,-282.50939 1089.3125,-282.8125 L 1089.3438,-283.0625 C 1089.367,-283.44867 1089.4027,-283.83818 1089.4062,-284.21875 L 1090.75,-304.03125 C 1091.2971,-308.38183 1090.5296,-312.62325 1088.25,-314.90625 L 1063.8438,-339.3125 C 1061.2601,-341.89616 1057.8584,-343.1667 1054.4062,-343.21875 z "
-         style="fill:url(#linearGradient5987);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    </clipPath>
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient5997"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016"
-       gradientUnits="userSpaceOnUse" />
-    <filter
-       id="filter6035">
-      <feGaussianBlur
-         stdDeviation="1.0516022"
-         id="feGaussianBlur6037" />
-    </filter>
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient6054"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9399678,-0.3412633,0.3412633,0.9399678,-245.87718,186.612)"
-       x1="1320.7188"
-       y1="-304.53207"
-       x2="1380.5529"
-       y2="-304.53207" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath6050">
-      <path
-         style="fill:url(#linearGradient6054);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 926.54247,-604.18385 C 924.00493,-603.30564 921.70629,-601.72078 919.96966,-599.6698 C 917.49162,-596.74326 917.03363,-592.66606 917.07797,-588.67945 C 909.0906,-585.32798 899.50618,-579.42564 896.85741,-564.61555 L 894.89667,-541.629 L 894.98475,-541.66096 C 894.9621,-541.53993 894.93698,-541.42538 894.91524,-541.30327 L 959.82132,-533.94936 L 973.09837,-538.76971 C 980.396,-541.41916 982.03859,-550.67337 980.25288,-558.25609 L 980.28221,-558.26674 L 980.21822,-558.44298 C 980.14561,-558.74116 980.05093,-559.02391 979.9677,-559.31616 L 979.91181,-559.56183 C 979.80183,-559.93274 979.70246,-560.31105 979.57587,-560.66996 L 974.07772,-579.75167 C 973.10729,-584.02777 970.93842,-587.75265 968.01657,-589.12066 L 936.74657,-603.7328 C 933.43626,-605.27964 929.80519,-605.31303 926.54247,-604.18385 z "
-         id="path6052" />
-    </clipPath>
-    <linearGradient
-       xlink:href="#linearGradient6060"
-       id="linearGradient6066"
-       x1="1040.7079"
-       y1="-346.50632"
-       x2="1051.4189"
-       y2="-306.53207"
-       gradientUnits="userSpaceOnUse" />
-    <filter
-       id="filter6072">
-      <feGaussianBlur
-         stdDeviation="0.083138439"
-         id="feGaussianBlur6074" />
-    </filter>
-    <filter
-       x="-0.11232839"
-       width="1.2246568"
-       y="-0.2265209"
-       height="1.4530418"
-       id="filter6198">
-      <feGaussianBlur
-         stdDeviation="0.4135875"
-         id="feGaussianBlur6200" />
-    </filter>
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient6285"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient6293"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient6299"
-       gradientUnits="userSpaceOnUse"
-       x1="1044.3829"
-       y1="-328.56128"
-       x2="1029.3492"
-       y2="-323.61151" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient6301"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient6332"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient6334"
-       gradientUnits="userSpaceOnUse"
-       x1="1044.3829"
-       y1="-328.56128"
-       x2="1029.3492"
-       y2="-323.61151" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient6336"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient6338"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient6340"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient6342"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient6344"
-       gradientUnits="userSpaceOnUse"
-       x1="1044.3829"
-       y1="-328.56128"
-       x2="1029.3492"
-       y2="-323.61151" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient6346"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient6375"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient6383"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient6389"
-       gradientUnits="userSpaceOnUse"
-       x1="1044.3829"
-       y1="-328.56128"
-       x2="1029.3492"
-       y2="-323.61151" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient6391"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient6495"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient6503"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient6509"
-       gradientUnits="userSpaceOnUse"
-       x1="1044.3829"
-       y1="-328.56128"
-       x2="1029.3492"
-       y2="-323.61151" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient6511"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient6519"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient6527"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient6533"
-       gradientUnits="userSpaceOnUse"
-       x1="1044.3829"
-       y1="-328.56128"
-       x2="1029.3492"
-       y2="-323.61151" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient6535"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <filter
-       id="filter6637">
-      <feGaussianBlur
-         stdDeviation="0.77462889"
-         id="feGaussianBlur6639" />
-    </filter>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath6641">
-      <path
-         style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.54011679;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="path6643"
-         d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-         transform="matrix(1.0730891,0,-2.0617613e-5,1.0737327,-111.41881,18.589863)" />
-    </clipPath>
-    <filter
-       x="-0.10593423"
-       width="1.2118685"
-       y="-0.14073338"
-       height="1.2814667"
-       id="filter6959">
-      <feGaussianBlur
-         stdDeviation="3.802569"
-         id="feGaussianBlur6961" />
-    </filter>
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient6969"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-445.13182,0)"
-       spreadMethod="reflect"
-       x1="1342.2097"
-       y1="-271.96814"
-       x2="1379.2245"
-       y2="-258.91791" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath6965">
-      <path
-         id="path6967"
-         d="M 919.4932,-293.5 C 906.89178,-293.5 896.30988,-286.92718 891.86818,-277.5 L 884.71198,-263 L 882.80568,-258.71875 C 881.75578,-255.7011 881.24428,-252.48284 881.36818,-249.125 C 881.98698,-232.358 898.17438,-218.74999 917.4932,-218.75 C 935.888,-218.75 950.513,-231.09546 951.337,-246.75 L 951.3682,-247.5625 L 951.3682,-266.53125 C 951.3672,-266.56286 951.3694,-266.59337 951.3682,-266.625 C 950.8223,-281.46 936.5362,-293.50001 919.4932,-293.5 z "
-         style="opacity:1;fill:url(#linearGradient6969);fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    </clipPath>
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient6997"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient7005"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8970666,-0.4418954,0.4418954,0.8970666,-319.69822,157.48348)"
-       spreadMethod="reflect"
-       x1="1342.2097"
-       y1="-271.96814"
-       x2="1379.2245"
-       y2="-258.91791" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath7001">
-      <path
-         id="path7003"
-         d="M 774.76499,-708.82707 C 763.46068,-703.25856 756.87251,-692.68621 757.05383,-682.26663 L 757.04173,-666.09688 L 757.22351,-661.41393 C 757.61517,-658.24295 758.57845,-655.12992 760.17341,-652.17247 C 768.13778,-637.4048 788.67227,-632.35064 806.00254,-640.88755 C 822.5039,-649.01613 830.16809,-666.55355 823.98961,-680.96083 L 823.65856,-681.70349 L 815.27635,-698.71972 C 815.26149,-698.74763 815.24998,-698.77598 815.23492,-698.80382 C 808.1897,-711.87057 790.05369,-716.3583 774.76499,-708.82707 z "
-         style="opacity:1;fill:url(#linearGradient7005);fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    </clipPath>
-    <filter
-       id="filter7023">
-      <feGaussianBlur
-         stdDeviation="0.60163542"
-         id="feGaussianBlur7025" />
-    </filter>
-    <filter
-       x="-0.19549701"
-       width="1.390994"
-       y="-0.091377147"
-       height="1.1827543"
-       id="filter7256">
-      <feGaussianBlur
-         stdDeviation="0.90989293"
-         id="feGaussianBlur7258" />
-    </filter>
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient7266"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9906907,0,0,0.9891472,-304.41345,-2.7970037)"
-       x1="1320.7188"
-       y1="-304.53207"
-       x2="1395.5529"
-       y2="-307.28207" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath7262">
-      <path
-         style="fill:url(#linearGradient7266);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 1054.7212,-342.29086 C 1052.0613,-342.3309 1049.385,-341.63329 1047.0744,-340.31257 C 1043.7774,-338.42805 1041.9724,-334.79181 1040.6659,-331.07022 C 1032.0948,-330.65036 1021.1742,-328.39787 1013.7005,-315.52207 L 1004.1032,-294.8118 L 1004.196,-294.8118 C 1004.134,-294.70691 1004.0719,-294.60888 1004.0103,-294.50269 L 1061.9658,-265.7556 L 1075.9593,-265.7556 C 1083.6507,-265.75559 1088.309,-273.80537 1089.2097,-281.45831 L 1089.2407,-281.45831 L 1089.2407,-281.64377 C 1089.2738,-281.94552 1089.2813,-282.24037 1089.3026,-282.54019 L 1089.3336,-282.78748 C 1089.3566,-283.16946 1089.3919,-283.55474 1089.3954,-283.93118 L 1090.7267,-303.52866 C 1091.2687,-307.83202 1090.5083,-312.02741 1088.25,-314.28563 L 1064.071,-338.427 C 1061.5113,-340.98262 1058.1413,-342.23938 1054.7212,-342.29086 z "
-         id="path7264" />
-    </clipPath>
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient7268"
-       gradientUnits="userSpaceOnUse"
-       x1="1043.125"
-       y1="-326.56128"
-       x2="1024.1875"
-       y2="-321.84375" />
-    <filter
-       id="filter7328">
-      <feGaussianBlur
-         stdDeviation="0.37286051"
-         id="feGaussianBlur7330" />
-    </filter>
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient7574"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient7584"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient7590"
-       gradientUnits="userSpaceOnUse"
-       x1="1043.125"
-       y1="-326.56128"
-       x2="1024.1875"
-       y2="-321.84375" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient7592"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <linearGradient
-       xlink:href="#linearGradient6060"
-       id="linearGradient7594"
-       gradientUnits="userSpaceOnUse"
-       x1="1040.7079"
-       y1="-346.50632"
-       x2="1051.4189"
-       y2="-306.53207" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient7602"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient7655"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient7665"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient7671"
-       gradientUnits="userSpaceOnUse"
-       x1="1043.125"
-       y1="-326.56128"
-       x2="1024.1875"
-       y2="-321.84375" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient7673"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <linearGradient
-       xlink:href="#linearGradient6060"
-       id="linearGradient7675"
-       gradientUnits="userSpaceOnUse"
-       x1="1040.7079"
-       y1="-346.50632"
-       x2="1051.4189"
-       y2="-306.53207" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient7683"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient7773"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient7783"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient7789"
-       gradientUnits="userSpaceOnUse"
-       x1="1043.125"
-       y1="-326.56128"
-       x2="1024.1875"
-       y2="-321.84375" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient7791"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <linearGradient
-       xlink:href="#linearGradient6060"
-       id="linearGradient7793"
-       gradientUnits="userSpaceOnUse"
-       x1="1040.7079"
-       y1="-346.50632"
-       x2="1051.4189"
-       y2="-306.53207" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient7801"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <filter
-       id="filter7845">
-      <feGaussianBlur
-         stdDeviation="0.26782521"
-         id="feGaussianBlur7847" />
-    </filter>
-    <filter
-       id="filter7958">
-      <feGaussianBlur
-         stdDeviation="0.37171029"
-         id="feGaussianBlur7960" />
-    </filter>
-    <filter
-       x="-0.041083101"
-       width="1.0821662"
-       y="-0.10220674"
-       height="1.2044135"
-       id="filter8002">
-      <feGaussianBlur
-         stdDeviation="0.81845238"
-         id="feGaussianBlur8004" />
-    </filter>
-    <radialGradient
-       xlink:href="#linearGradient7488"
-       id="radialGradient9002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.310521,0.1241025,-5.410353e-2,1.6889957,-487.03917,-8.4187541)"
-       cx="1524.2234"
-       cy="-260.47925"
-       fx="1521.5984"
-       fy="-250.7178"
-       r="24.75" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath8998">
-      <path
-         transform="matrix(1.1054471,0,3.5408698e-2,0.9594292,-810.10929,3.5391823)"
-         d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-         id="path9000"
-         style="opacity:1;fill:url(#radialGradient9002);fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    </clipPath>
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient9083"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient9150"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient9172"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient9174"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient9176"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient9178"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <linearGradient
-       xlink:href="#linearGradient10231"
-       id="linearGradient10239"
-       x1="1303.678"
-       y1="-279.19656"
-       x2="1317.4275"
-       y2="-290.21292"
-       gradientUnits="userSpaceOnUse" />
-    <filter
-       x="-0.16128817"
-       width="1.3225763"
-       y="-0.16123611"
-       height="1.3224722"
-       id="filter10253">
-      <feGaussianBlur
-         stdDeviation="0.98542663"
-         id="feGaussianBlur10255" />
-    </filter>
-    <linearGradient
-       xlink:href="#linearGradient9182"
-       id="linearGradient10263"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8534155,5.0231619e-2,-4.7703522e-2,0.9127427,-73.970807,-100.06198)"
-       spreadMethod="reflect"
-       x1="1587.483"
-       y1="-287.56335"
-       x2="1626.2708"
-       y2="-275.46451" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath10259">
-      <path
-         style="fill:url(#linearGradient10263);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 1294.6024,-283.29295 C 1294.6024,-283.29295 1301.5821,-288.3192 1308.5577,-287.90861 C 1316.3385,-287.45064 1321.8154,-281.43831 1321.8154,-281.43831 L 1313.6083,-273.70253 C 1313.6083,-273.70253 1311.2385,-275.86511 1308.2986,-276.1646 C 1305.3585,-276.46409 1301.8484,-274.90048 1301.8484,-274.90048 L 1294.6024,-283.29295 z "
-         id="path10261" />
-    </clipPath>
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient10405"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient10415"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient10421"
-       gradientUnits="userSpaceOnUse"
-       x1="1043.125"
-       y1="-326.56128"
-       x2="1024.1875"
-       y2="-321.84375" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient10423"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <linearGradient
-       xlink:href="#linearGradient6060"
-       id="linearGradient10425"
-       gradientUnits="userSpaceOnUse"
-       x1="1040.7079"
-       y1="-346.50632"
-       x2="1051.4189"
-       y2="-306.53207" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient10433"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient10441"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient10447"
-       gradientUnits="userSpaceOnUse"
-       x1="1044.3829"
-       y1="-328.56128"
-       x2="1029.3492"
-       y2="-323.61151" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient10449"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient10459"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient10481"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,2505.8129,0)"
-       spreadMethod="reflect"
-       x1="1342.2097"
-       y1="-271.96814"
-       x2="1379.2245"
-       y2="-258.91791" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient10483"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <radialGradient
-       xlink:href="#linearGradient7272"
-       id="radialGradient10485"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5767072,-0.3469395,0.2373397,1.1835928,-822.12269,572.60592)"
-       cx="1523.9357"
-       cy="-239.07518"
-       fx="1517.7112"
-       fy="-243.72826"
-       r="25.378679" />
-    <radialGradient
-       xlink:href="#linearGradient7029"
-       id="radialGradient10487"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5767072,-0.3469395,0.2373397,1.1835928,-822.12269,572.60592)"
-       cx="1513.9579"
-       cy="-242.04196"
-       fx="1510.811"
-       fy="-244.90619"
-       r="25.378679" />
-    <linearGradient
-       xlink:href="#linearGradient7384"
-       id="linearGradient10489"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect"
-       x1="1006.8612"
-       y1="-277.20105"
-       x2="1021.9153"
-       y2="-277.29233" />
-    <radialGradient
-       xlink:href="#linearGradient7488"
-       id="radialGradient10491"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.310521,0.1241025,-5.410353e-2,1.6889957,-487.03917,-8.4187541)"
-       cx="1524.2234"
-       cy="-260.47925"
-       fx="1521.5984"
-       fy="-250.7178"
-       r="24.75" />
-    <linearGradient
-       xlink:href="#linearGradient7402"
-       id="linearGradient10493"
-       gradientUnits="userSpaceOnUse"
-       x1="1531.7225"
-       y1="-294.20322"
-       x2="1516.595"
-       y2="-258.5531" />
-    <radialGradient
-       xlink:href="#linearGradient7974"
-       id="radialGradient10495"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.5441177,0,-105.7469)"
-       cx="1005.0781"
-       cy="-231.96094"
-       fx="1003.9062"
-       fy="-217.38396"
-       r="19.921875" />
-    <linearGradient
-       xlink:href="#linearGradient7866"
-       id="linearGradient10497"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-184.74879,-8.59375)"
-       spreadMethod="reflect"
-       x1="1191.0485"
-       y1="-239.6875"
-       x2="1218.4205"
-       y2="-239.6875" />
-    <linearGradient
-       xlink:href="#linearGradient7866"
-       id="linearGradient10499"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-184.74879,-8.59375)"
-       spreadMethod="reflect"
-       x1="1191.0485"
-       y1="-239.6875"
-       x2="1218.4205"
-       y2="-239.6875" />
-    <radialGradient
-       xlink:href="#linearGradient7964"
-       id="radialGradient10501"
-       gradientUnits="userSpaceOnUse"
-       cx="1029.1719"
-       cy="-242.67863"
-       fx="1028.6195"
-       fy="-244.88834"
-       r="4.9718447" />
-    <linearGradient
-       xlink:href="#linearGradient9015"
-       id="linearGradient10503"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,2059.1967,0)"
-       x1="871.22394"
-       y1="-296.40118"
-       x2="922.89081"
-       y2="-253.65625" />
-    <linearGradient
-       xlink:href="#linearGradient10231"
-       id="linearGradient10505"
-       gradientUnits="userSpaceOnUse"
-       x1="1303.678"
-       y1="-279.19656"
-       x2="1317.4275"
-       y2="-290.21292" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient10511"
-       gradientUnits="userSpaceOnUse"
-       x1="1308"
-       y1="-275"
-       x2="1315.6556"
-       y2="-297.19812" />
-    <linearGradient
-       xlink:href="#linearGradient10267"
-       id="linearGradient10550"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.782842,0,0,0.782842,-778.47277,287.76609)"
-       x1="1074.8013"
-       y1="-311.69385"
-       x2="1079.0005"
-       y2="-302.51416" />
-    <linearGradient
-       xlink:href="#linearGradient9182"
-       id="linearGradient10555"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.782842,0,0,0.782842,-1191.9076,282.25833)"
-       spreadMethod="reflect"
-       x1="1587.483"
-       y1="-287.56335"
-       x2="1603.283"
-       y2="-287.56335" />
-    <linearGradient
-       xlink:href="#linearGradient9182"
-       id="linearGradient10558"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.782842,0,-8.6195235e-3,0.5282035,-780.75521,211.75504)"
-       spreadMethod="reflect"
-       x1="1069.7126"
-       y1="-301.57309"
-       x2="1075.1814"
-       y2="-301.57309" />
-    <linearGradient
-       xlink:href="#linearGradient9182"
-       id="linearGradient10600"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6318731,0,0,0.6318731,-949.67764,230.1988)"
-       spreadMethod="reflect"
-       x1="1587.483"
-       y1="-287.56335"
-       x2="1626.2708"
-       y2="-275.46451" />
-    <radialGradient
-       xlink:href="#linearGradient6981"
-       id="radialGradient10642"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4057443,0.3407221,-0.226368,0.2695673,-457.0045,-206.60336)"
-       cx="1039.5222"
-       cy="-288.62067"
-       fx="1057.8066"
-       fy="-298.01926"
-       r="43.099228" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient10653"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6271489,-3.4784041e-2,3.4784041e-2,0.6271489,-810.83154,299.32446)"
-       x1="1320.7188"
-       y1="-304.53207"
-       x2="1395.5529"
-       y2="-307.28207" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient10693"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient10748"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient10789"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient10807"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient10929"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient10931"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient10933"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient10935"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient10937"
-       gradientUnits="userSpaceOnUse"
-       x1="1043.125"
-       y1="-326.56128"
-       x2="1024.1875"
-       y2="-321.84375" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient10939"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <linearGradient
-       xlink:href="#linearGradient6060"
-       id="linearGradient10941"
-       gradientUnits="userSpaceOnUse"
-       x1="1040.7079"
-       y1="-346.50632"
-       x2="1051.4189"
-       y2="-306.53207" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient10943"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient10945"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient10947"
-       gradientUnits="userSpaceOnUse"
-       x1="1044.3829"
-       y1="-328.56128"
-       x2="1029.3492"
-       y2="-323.61151" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient10949"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient10951"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient10953"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient10231"
-       id="linearGradient10955"
-       gradientUnits="userSpaceOnUse"
-       x1="1303.678"
-       y1="-279.19656"
-       x2="1317.4275"
-       y2="-290.21292" />
-    <radialGradient
-       xlink:href="#linearGradient10959"
-       id="radialGradient10965"
-       cx="64"
-       cy="122"
-       fx="23.043367"
-       fy="122"
-       r="64"
-       gradientTransform="matrix(1,0,0,9.375e-2,0,110.5625)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       xlink:href="#linearGradient10959"
-       id="radialGradient10969"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,9.375e-2,0,110.5625)"
-       cx="64"
-       cy="122"
-       fx="23.043367"
-       fy="122"
-       r="64" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient11145"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.2494356,-1.5365624e-2,-1.5122034e-2,0.2534536,421.1579,124.52335)"
-       spreadMethod="reflect"
-       x1="1342.2097"
-       y1="-271.96814"
-       x2="1379.2245"
-       y2="-258.91791" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient11147"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient7384"
-       id="linearGradient11149"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect"
-       x1="1006.8612"
-       y1="-277.20105"
-       x2="1021.9153"
-       y2="-277.29233" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient11151"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,2505.8129,0)"
-       spreadMethod="reflect"
-       x1="1342.2097"
-       y1="-271.96814"
-       x2="1379.2245"
-       y2="-258.91791" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient11153"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient9015"
-       id="linearGradient11173"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,2059.1967,0)"
-       x1="871.22394"
-       y1="-296.40118"
-       x2="922.89081"
-       y2="-253.65625" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2724"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.2494356,-1.5365624e-2,-1.5122034e-2,0.2534536,421.1579,124.52335)"
-       spreadMethod="reflect"
-       x1="1342.2097"
-       y1="-271.96814"
-       x2="1379.2245"
-       y2="-258.91791" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient2726"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient7384"
-       id="linearGradient2728"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect"
-       x1="1006.8612"
-       y1="-277.20105"
-       x2="1021.9153"
-       y2="-277.29233" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2730"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.2494356,-1.5365624e-2,-1.5122034e-2,0.2534536,421.1579,124.52335)"
-       spreadMethod="reflect"
-       x1="1342.2097"
-       y1="-271.96814"
-       x2="1379.2245"
-       y2="-258.91791" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient2732"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <linearGradient
-       xlink:href="#linearGradient7384"
-       id="linearGradient2734"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect"
-       x1="1006.8612"
-       y1="-277.20105"
-       x2="1021.9153"
-       y2="-277.29233" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2736"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6286128,-3.4784041e-2,3.4865234e-2,0.6271489,-812.72406,299.32446)"
-       x1="1320.7188"
-       y1="-304.53207"
-       x2="1395.5529"
-       y2="-307.28207" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient2738"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5626"
-       id="linearGradient2740"
-       gradientUnits="userSpaceOnUse"
-       x1="1050.3125"
-       y1="-359.12601"
-       x2="1053.8224"
-       y2="-304.62601" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2742"
-       gradientUnits="userSpaceOnUse"
-       x1="1308"
-       y1="-275"
-       x2="1315.6556"
-       y2="-297.19812" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2744"
-       gradientUnits="userSpaceOnUse"
-       x1="1308"
-       y1="-275"
-       x2="1315.6556"
-       y2="-297.19812" />
-    <radialGradient
-       xlink:href="#linearGradient6981"
-       id="radialGradient2746"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4066914,0.3407221,-0.2268964,0.2695673,-458.07112,-206.60336)"
-       cx="1039.5222"
-       cy="-288.62067"
-       fx="1057.8066"
-       fy="-298.01926"
-       r="43.099228" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient2748"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2750"
-       gradientUnits="userSpaceOnUse"
-       x1="1308"
-       y1="-275"
-       x2="1315.6556"
-       y2="-297.19812" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2752"
-       gradientUnits="userSpaceOnUse"
-       x1="1308"
-       y1="-275"
-       x2="1315.6556"
-       y2="-297.19812" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient2754"
-       gradientUnits="userSpaceOnUse"
-       x1="1043.125"
-       y1="-326.56128"
-       x2="1024.1875"
-       y2="-321.84375" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient2756"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <linearGradient
-       xlink:href="#linearGradient6060"
-       id="linearGradient2758"
-       gradientUnits="userSpaceOnUse"
-       x1="1040.7079"
-       y1="-346.50632"
-       x2="1051.4189"
-       y2="-306.53207" />
-    <radialGradient
-       xlink:href="#linearGradient6202"
-       id="radialGradient2760"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2777006,2.2216495e-2,-6.9657162e-3,0.4006077,-291.86317,-217.50591)"
-       cx="1041.8312"
-       cy="-325.97409"
-       fx="1041.8312"
-       fy="-325.97409"
-       r="5.6264501" />
-    <linearGradient
-       xlink:href="#linearGradient7029"
-       id="linearGradient2762"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.25,0.25)"
-       x1="990.33337"
-       y1="-289.2814"
-       x2="1000.7026"
-       y2="-309.96426" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2764"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,2302.3627,36.5)"
-       x1="1320.7188"
-       y1="-304.53207"
-       x2="1395.5529"
-       y2="-307.28207" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient2766"
-       gradientUnits="userSpaceOnUse"
-       x1="924.28729"
-       y1="-593.10016"
-       x2="940.11462"
-       y2="-593.10016" />
-    <linearGradient
-       xlink:href="#linearGradient5626"
-       id="linearGradient2768"
-       gradientUnits="userSpaceOnUse"
-       x1="1050.3125"
-       y1="-359.12601"
-       x2="1053.8224"
-       y2="-304.62601" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2770"
-       gradientUnits="userSpaceOnUse"
-       x1="1308"
-       y1="-275"
-       x2="1315.6556"
-       y2="-297.19812" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2772"
-       gradientUnits="userSpaceOnUse"
-       x1="1308"
-       y1="-275"
-       x2="1315.6556"
-       y2="-297.19812" />
-    <linearGradient
-       xlink:href="#linearGradient5761"
-       id="linearGradient2774"
-       gradientUnits="userSpaceOnUse"
-       x1="1143.447"
-       y1="-320.30569"
-       x2="1150.2383"
-       y2="-265.85849" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2776"
-       gradientUnits="userSpaceOnUse"
-       x1="1308"
-       y1="-275"
-       x2="1315.6556"
-       y2="-297.19812" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2778"
-       gradientUnits="userSpaceOnUse"
-       x1="1308"
-       y1="-275"
-       x2="1315.6556"
-       y2="-297.19812" />
-    <linearGradient
-       xlink:href="#linearGradient5811"
-       id="linearGradient2780"
-       gradientUnits="userSpaceOnUse"
-       x1="1044.3829"
-       y1="-328.56128"
-       x2="1029.3492"
-       y2="-323.61151" />
-    <radialGradient
-       xlink:href="#linearGradient5925"
-       id="radialGradient2782"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4655537,0.2803301,-180.87111)"
-       cx="1058.0344"
-       cy="-345.89316"
-       fx="1058.0344"
-       fy="-345.89316"
-       r="11.9646" />
-    <linearGradient
-       xlink:href="#linearGradient6060"
-       id="linearGradient2784"
-       gradientUnits="userSpaceOnUse"
-       x1="1040.7079"
-       y1="-346.50632"
-       x2="1051.4189"
-       y2="-306.53207" />
-    <radialGradient
-       xlink:href="#linearGradient6202"
-       id="radialGradient2786"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3444016,0,0,0.4006683,-359.14395,-194.31864)"
-       cx="1041.8312"
-       cy="-325.97409"
-       fx="1041.8312"
-       fy="-325.97409"
-       r="5.6264501" />
-    <linearGradient
-       xlink:href="#linearGradient9182"
-       id="linearGradient2788"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.633348,0,0,0.6318731,-951.89425,230.1988)"
-       spreadMethod="reflect"
-       x1="1587.483"
-       y1="-287.56335"
-       x2="1626.2708"
-       y2="-275.46451" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2790"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-356.38182,0)"
-       spreadMethod="reflect"
-       x1="1342.2097"
-       y1="-271.96814"
-       x2="1379.2245"
-       y2="-258.91791" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient2792"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <radialGradient
-       xlink:href="#linearGradient7272"
-       id="radialGradient2794"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5767072,-0.3469395,0.2373397,1.1835928,-822.12269,572.60592)"
-       cx="1523.9357"
-       cy="-239.07518"
-       fx="1530.712"
-       fy="-239.9174"
-       r="25.378679" />
-    <radialGradient
-       xlink:href="#linearGradient7029"
-       id="radialGradient2796"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5767072,-0.3469395,0.2373397,1.1835928,-822.12269,572.60592)"
-       cx="1523.9357"
-       cy="-239.07518"
-       fx="1520.7888"
-       fy="-241.93941"
-       r="25.378679" />
-    <linearGradient
-       xlink:href="#linearGradient7384"
-       id="linearGradient2798"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect"
-       x1="1006.8612"
-       y1="-277.20105"
-       x2="1021.9153"
-       y2="-277.29233" />
-    <radialGradient
-       xlink:href="#linearGradient7488"
-       id="radialGradient2800"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.310521,0.1241025,-5.410353e-2,1.6889957,-487.03917,-8.4187541)"
-       cx="1524.2234"
-       cy="-260.47925"
-       fx="1521.5984"
-       fy="-250.7178"
-       r="24.75" />
-    <linearGradient
-       xlink:href="#linearGradient7402"
-       id="linearGradient2802"
-       gradientUnits="userSpaceOnUse"
-       x1="1514.1305"
-       y1="-288.6954"
-       x2="1527.4935"
-       y2="-257.32666" />
-    <radialGradient
-       xlink:href="#linearGradient7974"
-       id="radialGradient2804"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9983399,5.7596578e-2,-2.9411765e-2,0.5098035,-5.1538898,-171.5955)"
-       cx="1005.0781"
-       cy="-231.96094"
-       fx="1003.9062"
-       fy="-217.38396"
-       r="19.921875" />
-    <linearGradient
-       xlink:href="#linearGradient7866"
-       id="linearGradient2806"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-184.74879,-8.59375)"
-       spreadMethod="reflect"
-       x1="1191.0485"
-       y1="-239.6875"
-       x2="1218.4205"
-       y2="-239.6875" />
-    <linearGradient
-       xlink:href="#linearGradient7866"
-       id="linearGradient2808"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-184.74879,-8.59375)"
-       spreadMethod="reflect"
-       x1="1191.0485"
-       y1="-239.6875"
-       x2="1218.4205"
-       y2="-239.6875" />
-    <radialGradient
-       xlink:href="#linearGradient7964"
-       id="radialGradient2810"
-       gradientUnits="userSpaceOnUse"
-       cx="1029.1719"
-       cy="-242.67863"
-       fx="1028.6195"
-       fy="-244.88834"
-       r="4.9718447" />
-    <linearGradient
-       xlink:href="#linearGradient9015"
-       id="linearGradient2812"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(90.234375,0)"
-       x1="941.53644"
-       y1="-297.18243"
-       x2="905.31268"
-       y2="-260.95868" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2814"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.6284252,-3.8009559e-2,-3.8098281e-2,0.6269617,952.11484,294.35449)"
-       spreadMethod="reflect"
-       x1="1342.2097"
-       y1="-271.96814"
-       x2="1379.2245"
-       y2="-258.91791" />
-    <linearGradient
-       xlink:href="#linearGradient5991"
-       id="linearGradient2816"
-       gradientUnits="userSpaceOnUse"
-       x1="758.87622"
-       y1="-688.4256"
-       x2="765.15649"
-       y2="-688.52112" />
-    <radialGradient
-       xlink:href="#linearGradient7272"
-       id="radialGradient2818"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5767072,-0.3469395,0.2373397,1.1835928,-822.12269,572.60592)"
-       cx="1523.9357"
-       cy="-239.07518"
-       fx="1517.7112"
-       fy="-243.72826"
-       r="25.378679" />
-    <radialGradient
-       xlink:href="#linearGradient7029"
-       id="radialGradient2820"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5767072,-0.3469395,0.2373397,1.1835928,-822.12269,572.60592)"
-       cx="1513.9579"
-       cy="-242.04196"
-       fx="1510.811"
-       fy="-244.90619"
-       r="25.378679" />
-    <linearGradient
-       xlink:href="#linearGradient7384"
-       id="linearGradient2822"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect"
-       x1="1006.8612"
-       y1="-277.20105"
-       x2="1021.9153"
-       y2="-277.29233" />
-    <radialGradient
-       xlink:href="#linearGradient7488"
-       id="radialGradient2824"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.310521,0.1241025,-5.410353e-2,1.6889957,-487.03917,-8.4187541)"
-       cx="1524.2234"
-       cy="-260.47925"
-       fx="1521.5984"
-       fy="-250.7178"
-       r="24.75" />
-    <linearGradient
-       xlink:href="#linearGradient7402"
-       id="linearGradient2826"
-       gradientUnits="userSpaceOnUse"
-       x1="1531.7225"
-       y1="-294.20322"
-       x2="1516.595"
-       y2="-258.5531" />
-    <radialGradient
-       xlink:href="#linearGradient7974"
-       id="radialGradient2828"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.5441177,0,-105.7469)"
-       cx="1005.0781"
-       cy="-231.96094"
-       fx="1003.9062"
-       fy="-217.38396"
-       r="19.921875" />
-    <linearGradient
-       xlink:href="#linearGradient7866"
-       id="linearGradient2830"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-184.74879,-8.59375)"
-       spreadMethod="reflect"
-       x1="1191.0485"
-       y1="-239.6875"
-       x2="1218.4205"
-       y2="-239.6875" />
-    <linearGradient
-       xlink:href="#linearGradient7866"
-       id="linearGradient2832"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-184.74879,-8.59375)"
-       spreadMethod="reflect"
-       x1="1191.0485"
-       y1="-239.6875"
-       x2="1218.4205"
-       y2="-239.6875" />
-    <radialGradient
-       xlink:href="#linearGradient7964"
-       id="radialGradient2834"
-       gradientUnits="userSpaceOnUse"
-       cx="1029.1719"
-       cy="-242.67863"
-       fx="1028.6195"
-       fy="-244.88834"
-       r="4.9718447" />
-    <linearGradient
-       xlink:href="#linearGradient9015"
-       id="linearGradient2836"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.6284252,-3.8009559e-2,-3.8098281e-2,0.6269617,671.44997,277.37881)"
-       x1="871.22394"
-       y1="-296.40118"
-       x2="922.89081"
-       y2="-253.65625" />
-    <linearGradient
-       xlink:href="#linearGradient10231"
-       id="linearGradient2838"
-       gradientUnits="userSpaceOnUse"
-       x1="1303.678"
-       y1="-279.19656"
-       x2="1317.4275"
-       y2="-290.21292" />
-    <linearGradient
-       xlink:href="#linearGradient9182"
-       id="linearGradient2840"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7846693,0,-8.6396432e-3,0.5282035,-782.57752,211.75504)"
-       spreadMethod="reflect"
-       x1="1069.7126"
-       y1="-301.57309"
-       x2="1075.1814"
-       y2="-301.57309" />
-    <linearGradient
-       xlink:href="#linearGradient9182"
-       id="linearGradient2842"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7846693,0,0,0.782842,-1194.6896,282.25833)"
-       spreadMethod="reflect"
-       x1="1587.483"
-       y1="-287.56335"
-       x2="1603.283"
-       y2="-287.56335" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2844"
-       gradientUnits="userSpaceOnUse"
-       x1="1308"
-       y1="-275"
-       x2="1311.5271"
-       y2="-291.92001" />
-    <linearGradient
-       xlink:href="#linearGradient10267"
-       id="linearGradient2846"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7846693,0,0,0.782842,-780.28976,287.76609)"
-       x1="1074.8013"
-       y1="-311.69385"
-       x2="1079.0005"
-       y2="-302.51416" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2848"
-       gradientUnits="userSpaceOnUse"
-       x1="1308"
-       y1="-275"
-       x2="1315.6556"
-       y2="-297.19812" />
-    <linearGradient
-       xlink:href="#linearGradient5595"
-       id="linearGradient2850"
-       gradientUnits="userSpaceOnUse"
-       x1="1308"
-       y1="-275"
-       x2="1315.6556"
-       y2="-297.19812" />
-    <linearGradient
-       xlink:href="#linearGradient11200"
-       id="linearGradient2852"
-       gradientUnits="userSpaceOnUse"
-       x1="1302.9651"
-       y1="-275.40384"
-       x2="1307.9283"
-       y2="-280.12851" />
-    <filter
-       id="filter3606">
-      <feGaussianBlur
-         stdDeviation="0.50964986"
-         id="feGaussianBlur3608" />
-    </filter>
-  </defs>
-  <metadata
-     id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     id="layer1"
-     transform="translate(0.852533,-30.838506)">
-    <path
-       id="path2276"
-       d="M -106.3852,44.124126 L -106.3852,41.329417 L -106.3852,44.124126 z "
-       style="fill:#ffffff;fill-opacity:0.75688076;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:4;stroke-opacity:1" />
-    <path
-       style="opacity:0.12820512;fill:url(#radialGradient10965);fill-opacity:1;stroke:none;stroke-width:1.39999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path10957"
-       d="M 128 122 A 64 6 0 1 1  0,122 A 64 6 0 1 1  128 122 z"
-       transform="translate(-0.852533,30.838506)" />
-    <path
-       d="M 128 122 A 64 6 0 1 1  0,122 A 64 6 0 1 1  128 122 z"
-       id="path10967"
-       style="opacity:0.12820512;fill:url(#radialGradient10969);fill-opacity:1;stroke:none;stroke-width:1.39999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       transform="matrix(-1,0,0,1,127.14747,30.838506)" />
-    <g
-       id="g2608"
-       transform="matrix(0.9989622,0,0,0.9650055,-0.7991554,32.80271)">
-      <g
-         id="g10793"
-         transform="matrix(-1.0023342,0,0,1,125.81359,1.975368)">
-        <path
-           id="path10795"
-           d="M 85.210188,29.166425 C 88.353428,29.360054 90.893538,31.188556 91.858898,33.646158 L 93.424638,37.431194 L 93.835398,38.545583 C 94.051648,39.326554 94.130568,40.150084 94.048878,40.999244 C 93.640978,45.239394 89.397488,48.439654 84.578688,48.142814 C 79.990378,47.860164 76.529068,44.506444 76.560258,40.526084 L 76.564768,40.319664 L 76.851608,35.511972 C 76.852338,35.503975 76.852248,35.496209 76.853028,35.48821 C 77.213528,31.736615 80.959058,28.904547 85.210188,29.166425 z "
-           style="fill:url(#linearGradient2724);fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        <rect
-           clip-path="url(#clipPath7001)"
-           ry="0"
-           transform="matrix(-0.2304427,9.8215979e-2,9.6658966e-2,0.2341547,332.2636,119.04733)"
-           y="-703.20679"
-           x="758.11121"
-           height="28.852757"
-           width="7.9257522"
-           id="rect10797"
-           style="opacity:0.5677656;fill:url(#linearGradient2726);fill-opacity:1;stroke:none;stroke-width:3.79999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter7023)" />
-        <path
-           style="fill:#312f30;fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="path10799"
-           d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-           transform="matrix(-0.3527155,-2.1727829e-2,-2.9856727e-2,0.3103607,615.22447,155.68135)" />
-        <path
-           clip-path="url(#clipPath6641)"
-           style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:3.10063338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter6637)"
-           id="path10801"
-           d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-           transform="matrix(-0.3282324,-2.0219636e-2,-2.7774152e-2,0.2886478,578.43537,147.79709)" />
-        <path
-           transform="matrix(-0.2513269,-1.3786663e-2,-1.6106843e-2,0.2786409,333.81048,124.47686)"
-           id="path10803"
-           d="M 1021.25,-275.25 C 1015.275,-279.38684 1000.1752,-280.67307 992.5,-277.75"
-           style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:url(#linearGradient2728);stroke-width:1.33052707;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter7845)" />
-      </g>
-      <g
-         transform="matrix(1.0023342,0,0,1,1.7620403,2.1484375)"
-         id="g10774">
-        <path
-           style="fill:url(#linearGradient2730);fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           d="M 85.210188,29.166425 C 88.353428,29.360054 90.893538,31.188556 91.858898,33.646158 L 93.424638,37.431194 L 93.835398,38.545583 C 94.051648,39.326554 94.130568,40.150084 94.048878,40.999244 C 93.640978,45.239394 89.397488,48.439654 84.578688,48.142814 C 79.990378,47.860164 76.529068,44.506444 76.560258,40.526084 L 76.564768,40.319664 L 76.851608,35.511972 C 76.852338,35.503975 76.852248,35.496209 76.853028,35.48821 C 77.213528,31.736615 80.959058,28.904547 85.210188,29.166425 z "
-           id="path10657" />
-        <rect
-           style="opacity:0.5677656;fill:url(#linearGradient2732);fill-opacity:1;stroke:none;stroke-width:3.79999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter7023)"
-           id="rect10659"
-           width="7.9257522"
-           height="28.852757"
-           x="758.11121"
-           y="-703.20679"
-           transform="matrix(-0.2304427,9.8215979e-2,9.6658966e-2,0.2341547,332.2636,119.04733)"
-           ry="0"
-           clip-path="url(#clipPath7001)" />
-        <path
-           transform="matrix(-0.3527155,-2.1727829e-2,-2.9856727e-2,0.3103607,615.22447,155.68135)"
-           d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-           id="path10661"
-           style="fill:#312f30;fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        <path
-           transform="matrix(-0.3282324,-2.0219636e-2,-2.7774152e-2,0.2886478,578.43537,147.79709)"
-           d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-           id="path10663"
-           style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:3.10063338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter6637)"
-           clip-path="url(#clipPath6641)" />
-        <path
-           style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:url(#linearGradient2734);stroke-width:1.33052707;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter7845)"
-           d="M 1021.25,-275.25 C 1015.275,-279.38684 1000.1752,-280.67307 992.5,-277.75"
-           id="path10669"
-           transform="matrix(-0.2513269,-1.3786663e-2,-1.6106843e-2,0.2786409,333.81048,124.47686)" />
-      </g>
-      <path
-         id="path5585"
-         d="M 37.707324,36.354753 C 36.018164,36.422759 34.344554,36.959035 32.92498,37.877543 C 30.899372,39.188138 29.882287,41.556996 29.184462,43.962468 C 23.760703,44.529616 16.910758,46.341194 12.622393,54.767245 L 7.2626997,68.235146 L 7.3215968,68.231886 C 7.2859438,68.30057 7.2499823,68.364901 7.2146881,68.434389 L 45.001815,84.626038 L 53.880956,84.134716 C 58.761326,83.864665 61.433384,78.597311 61.735204,73.713489 L 61.754785,73.712402 L 61.748237,73.594813 C 61.758688,73.402328 61.753022,73.215132 61.755917,73.024286 L 61.766872,72.86641 C 61.768006,72.623418 61.776882,72.377895 61.765801,72.139099 L 61.919797,59.666971 C 62.112008,56.919474 61.481673,54.286173 59.969109,52.933683 L 43.776088,38.476279 C 42.06187,36.945807 39.879246,36.267319 37.707324,36.354753 z "
-         style="fill:url(#linearGradient2736);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <rect
-         clip-path="url(#clipPath6050)"
-         transform="matrix(0.6027739,0.1813271,-0.1817504,0.6013702,-630.59892,231.68574)"
-         y="-612.89917"
-         x="924.42279"
-         height="39.59798"
-         width="15.556347"
-         id="rect5989"
-         style="opacity:0.73260073;fill:url(#linearGradient2738);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter6035)" />
-      <path
-         id="path5581"
-         d="M 44.950441,84.619612 L 53.840347,84.127693 C 61.711407,83.692154 63.874451,70.281437 59.537092,66.403116 L 41.627398,50.413073 C 38.256569,47.403502 33.197525,47.430354 29.608484,49.752581 C 27.367875,51.202272 26.254528,53.830622 25.482538,56.491371 C 19.483344,57.118686 11.908924,59.11795 7.1655305,68.438177 L 44.950441,84.619612 z "
-         style="fill:#3d3b3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <path
-         transform="matrix(0.6286128,-3.4784041e-2,3.4865234e-2,0.6271489,-613.1395,288.28052)"
-         id="path5603"
-         d="M 1049.3125,-326.3125 C 1046.1915,-326.35956 1043.0548,-325.5833 1040.3438,-324.03125 C 1036.4753,-321.81664 1034.127,-318.02969 1032.5938,-313.65625 C 1024.9999,-313.28369 1015.5894,-309.93082 1007.7812,-302.65625 L 1003.3125,-295.21875 C 1011.6513,-309.33743 1023.751,-311.81522 1033.25,-312.28125 C 1034.7089,-316.44294 1036.6937,-320.51762 1040.375,-322.625 C 1046.2717,-326.00078 1054.2944,-325.61187 1059.375,-320.53125 L 1086.375,-293.53125 C 1089.0339,-290.86837 1089.8728,-285.80046 1089.0625,-280.71875 C 1089.1202,-281.05209 1089.1796,-281.38581 1089.2188,-281.71875 L 1089.25,-281.71875 L 1089.25,-281.90625 C 1089.2835,-282.21131 1089.291,-282.50939 1089.3125,-282.8125 L 1089.3438,-283.0625 C 1089.367,-283.44867 1089.4029,-283.83818 1089.4062,-284.21875 L 1089.9688,-292.01164 C 1089.5375,-292.853 1089.0253,-293.61043 1088.4062,-294.23039 L 1060.3125,-321.8125 C 1057.3093,-324.81575 1053.3252,-326.252 1049.3125,-326.3125 z M 1084.4062,-270.0625 C 1084.0397,-269.63847 1083.657,-269.24582 1083.25,-268.875 C 1083.6571,-269.24538 1084.0399,-269.63783 1084.4062,-270.0625 z M 1079,-266.34375 C 1078.707,-266.24974 1078.3981,-266.19324 1078.0938,-266.125 C 1078.3983,-266.19141 1078.7069,-266.25151 1079,-266.34375 z M 1077.9375,-266.0625 C 1077.6397,-266.00077 1077.3398,-265.97343 1077.0312,-265.9375 C 1077.3347,-265.9716 1077.6445,-266.0034 1077.9375,-266.0625 z "
-         style="fill:url(#linearGradient2740);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5622)" />
-      <g
-         transform="matrix(0.6286128,-3.4784041e-2,3.4865234e-2,0.6271489,-641.43935,292.51544)"
-         id="g5708">
-        <path
-           style="opacity:1;fill:#1f1f1f;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871;filter:url(#filter5698)"
-           id="path5702"
-           d="M 1314.2336 -281.5 A 6.2335539 6.2335539 0 1 1  1301.7664,-281.5 A 6.2335539 6.2335539 0 1 1  1314.2336 -281.5 z"
-           transform="matrix(1.4081633,0,0,1.3269231,-724.50257,90.278845)" />
-        <path
-           transform="matrix(1.2649603,0,0,1.1919818,-537.19298,53.16998)"
-           d="M 1314.5 -281.5 A 6.5 6.5 0 1 1  1301.5,-281.5 A 6.5 6.5 0 1 1  1314.5 -281.5 z"
-           id="path5704"
-           style="opacity:1;fill:url(#linearGradient2742);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871" />
-      </g>
-      <path
-         style="fill:#3b3b3b;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871;filter:url(#filter5698)"
-         id="path5636"
-         d="M 1314.1105 -281.5 A 6.1104922 6.1104922 0 1 1  1301.8895,-281.5 A 6.1104922 6.1104922 0 1 1  1314.1105 -281.5 z"
-         transform="matrix(0.7569011,-4.1882828e-2,3.9558632e-2,0.7115728,-927.76603,331.88311)" />
-      <path
-         transform="matrix(0.6799281,-3.7623557e-2,3.553572e-2,0.6392095,-828.19165,306.41206)"
-         d="M 1314.5 -281.5 A 6.5 6.5 0 1 1  1301.5,-281.5 A 6.5 6.5 0 1 1  1314.5 -281.5 z"
-         id="path5634"
-         style="fill:url(#linearGradient2744);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871" />
-      <path
-         style="fill:url(#radialGradient2746);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 44.950441,84.619612 L 53.840347,84.127693 C 61.711407,83.692154 63.874451,70.281437 59.537092,66.403116 L 41.627398,50.413073 C 38.256569,47.403502 33.197525,47.430354 29.608484,49.752581 C 27.367875,51.202272 26.254528,53.830622 25.482538,56.491371 C 19.483344,57.118686 11.908924,59.11795 7.1655305,68.438177 L 44.950441,84.619612 z "
-         id="path6971" />
-      <path
-         transform="matrix(0.6286128,-3.4784041e-2,3.4865234e-2,0.6271489,-678.51524,291.89806)"
-         clip-path="url(#clipPath5757)"
-         id="path5716"
-         d="M 1152.875,-323.8125 C 1149.9555,-323.85652 1147.0048,-323.1081 1144.4688,-321.65625 C 1140.85,-319.58462 1138.9029,-315.59111 1137.4688,-311.5 C 1128.0614,-311.03845 1116.078,-308.5605 1107.875,-294.40625 L 1108.7723,-294.06158 C 1116.653,-307.46902 1128.7996,-310.16145 1137.792,-310.60263 C 1139.1706,-314.53493 1141.2404,-318.39265 1144.7188,-320.38388 C 1150.2904,-323.57359 1157.8558,-322.83089 1162.6562,-318.03033 L 1188.1562,-292 C 1189.7365,-290.05686 1189.9873,-265.84374 1178.1562,-265.84375 L 1179.2812,-265.84375 C 1191.5902,-265.84374 1196.1134,-286.62691 1189.6875,-293.0625 L 1163.1562,-319.59375 C 1160.3469,-322.40313 1156.6287,-323.7559 1152.875,-323.8125 z "
-         style="opacity:0.82417585;fill:url(#linearGradient2748);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5753)" />
-      <rect
-         transform="matrix(0.7740326,0.6331457,-0.8117013,0.5840727,0,0)"
-         y="25.317707"
-         x="95.235893"
-         height="6.2907763"
-         width="1.3014547"
-         id="rect5769"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871" />
-      <g
-         transform="matrix(0.6286128,-3.4784041e-2,3.4865234e-2,0.6271489,-609.11292,272.48883)"
-         id="g5787">
-        <path
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871;filter:url(#filter5698)"
-           id="path5779"
-           d="M 1314.1105 -281.5 A 6.1104922 6.1104922 0 1 1  1301.8895,-281.5 A 6.1104922 6.1104922 0 1 1  1314.1105 -281.5 z"
-           transform="matrix(0.2349258,0,0,0.2213724,740.7956,-231.71638)" />
-        <path
-           transform="matrix(0.2110351,0,0,0.19886,772.04472,-237.9073)"
-           d="M 1314.5 -281.5 A 6.5 6.5 0 1 1  1301.5,-281.5 A 6.5 6.5 0 1 1  1314.5 -281.5 z"
-           id="path5781"
-           style="opacity:1;fill:url(#linearGradient2750);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871" />
-        <rect
-           transform="matrix(0.7370101,0.6758817,-0.8422052,0.5391571,0,0)"
-           y="-957.89124"
-           x="328.35144"
-           height="1.951079"
-           width="0.40370131"
-           id="rect5783"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871" />
-      </g>
-      <g
-         id="g5794"
-         transform="matrix(0.6286128,-3.4784041e-2,3.4865234e-2,0.6271489,-620.04042,276.42969)">
-        <path
-           transform="matrix(0.2349258,0,0,0.2213724,740.7956,-231.71638)"
-           d="M 1314.1105 -281.5 A 6.1104922 6.1104922 0 1 1  1301.8895,-281.5 A 6.1104922 6.1104922 0 1 1  1314.1105 -281.5 z"
-           id="path5796"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871;filter:url(#filter5698)" />
-        <path
-           style="opacity:1;fill:url(#linearGradient2752);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871"
-           id="path5798"
-           d="M 1314.5 -281.5 A 6.5 6.5 0 1 1  1301.5,-281.5 A 6.5 6.5 0 1 1  1314.5 -281.5 z"
-           transform="matrix(0.2110351,0,0,0.19886,772.04472,-237.9073)" />
-        <rect
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871"
-           id="rect5800"
-           width="0.40370131"
-           height="1.951079"
-           x="328.35144"
-           y="-957.89124"
-           transform="matrix(0.7370101,0.6758817,-0.8422052,0.5391571,0,0)" />
-      </g>
-      <path
-         transform="matrix(0.6286128,-3.4784041e-2,3.4865234e-2,0.6271489,-613.1395,288.28052)"
-         clip-path="url(#clipPath5917)"
-         id="path5806"
-         d="M 1040.125,-331.875 C 1035.6409,-331.6486 1023.5262,-330.40257 1020.3438,-324.6875 L 1024.1875,-313.90625 L 1033.0938,-311.8125 L 1040.125,-331.875 z "
-         style="fill:url(#linearGradient2754);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5911)" />
-      <path
-         transform="matrix(0.6286128,-3.4784041e-2,3.4865234e-2,0.6271489,-613.1395,288.28052)"
-         clip-path="url(#clipPath5983)"
-         id="path5923"
-         d="M 1046.8867,-340.80107 C 1052.2341,-343.88841 1059.5378,-342.79045 1063.1631,-339.16517 L 1069.7793,-332.64529"
-         style="opacity:0.73260073;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#radialGradient2756);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5977)" />
-      <path
-         transform="matrix(0.6345197,-3.51109e-2,3.5247772e-2,0.6340299,-619.46913,290.40961)"
-         style="opacity:0.58241763;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2758);stroke-width:0.59395117;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter6072)"
-         d="M 1088.25,-312.40625 L 1063.8438,-336.8125 C 1061.2601,-339.39616 1057.8584,-340.6667 1054.4062,-340.71875 C 1051.7213,-340.75923 1049.0198,-340.05396 1046.6875,-338.71875 C 1043.3595,-336.81356 1041.5376,-333.13742 1040.2188,-329.375 C 1031.5672,-328.95053 1020.1061,-326.5859 1012.5622,-313.56882"
-         id="path6056"
-         clip-path="url(#clipPath7262)" />
-      <path
-         transform="matrix(0.6286128,-3.4784041e-2,3.4865234e-2,0.6271489,-613.1395,288.28052)"
-         id="path6076"
-         d="M 1037.5404,-321.53372 C 1040.5373,-324.57054 1044.6518,-326.13621 1048.4183,-325.96256"
-         style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:url(#radialGradient2760);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter6198)" />
-      <path
-         transform="matrix(0.6286128,-3.4784041e-2,3.4865234e-2,0.6271489,-601.12498,277.55429)"
-         id="path7027"
-         d="M 999.92222,-306.62067 L 989.31561,-286.82168"
-         style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:url(#linearGradient2762);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter7256)" />
-      <g
-         transform="matrix(0.6284252,3.8009559e-2,-3.8098281e-2,0.6269617,-506.28532,193.24109)"
-         id="g6348">
-        <path
-           id="path6237"
-           d="M 930.4565,-306.71875 C 933.1414,-306.75923 935.8429,-306.05396 938.1752,-304.71875 C 941.5032,-302.81356 943.3251,-299.13742 944.6439,-295.375 C 953.2955,-294.95053 964.3188,-292.67333 971.8627,-279.65625 L 981.5502,-258.71875 L 981.4565,-258.71875 C 981.5191,-258.61271 981.5818,-258.51361 981.6439,-258.40625 L 923.1439,-229.34375 L 909.0189,-229.34375 C 901.2552,-229.34374 896.5531,-237.48184 895.6439,-245.21875 L 895.6127,-245.21875 L 895.6127,-245.40625 C 895.5792,-245.71131 895.5717,-246.00939 895.5502,-246.3125 L 895.5189,-246.5625 C 895.4957,-246.94867 895.46,-247.33818 895.4565,-247.71875 L 894.1127,-267.53125 C 893.5656,-271.88183 894.3331,-276.12325 896.6127,-278.40625 L 921.0189,-302.8125 C 923.6026,-305.39616 927.0043,-306.6667 930.4565,-306.71875 z "
-           style="fill:url(#linearGradient2764);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-        <rect
-           clip-path="url(#clipPath6050)"
-           transform="matrix(-0.9399677,0.3412633,0.3412633,0.9399677,2007.5623,-55.00039)"
-           y="-612.89917"
-           x="924.42279"
-           height="39.59798"
-           width="15.556347"
-           id="rect6239"
-           style="opacity:0.73260073;fill:url(#linearGradient2766);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter6035)" />
-        <path
-           id="path6241"
-           d="M 923.2248,-229.35848 L 909.0827,-229.35848 C 896.5614,-229.35848 891.9486,-250.48626 898.4854,-257.03287 L 925.479,-284.02644 C 930.5596,-289.10705 938.5852,-289.50936 944.4819,-286.13358 C 948.1631,-284.0262 950.1606,-279.94603 951.6195,-275.78434 C 961.1891,-275.31484 973.3778,-272.80301 981.7222,-258.40456 L 923.2248,-229.35848 z "
-           style="fill:#3d3b3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-        <path
-           id="path6243"
-           d="M 1049.3125,-326.3125 C 1046.1915,-326.35956 1043.0548,-325.5833 1040.3438,-324.03125 C 1036.4753,-321.81664 1034.127,-318.02969 1032.5938,-313.65625 C 1024.9999,-313.28369 1015.5894,-309.93082 1007.7812,-302.65625 L 1003.3125,-295.21875 C 1011.6513,-309.33743 1023.751,-311.81522 1033.25,-312.28125 C 1034.7089,-316.44294 1036.6937,-320.51762 1040.375,-322.625 C 1046.2717,-326.00078 1054.2944,-325.61187 1059.375,-320.53125 L 1086.375,-293.53125 C 1089.0339,-290.86837 1089.8728,-285.80046 1089.0625,-280.71875 C 1089.1202,-281.05209 1089.1796,-281.38581 1089.2188,-281.71875 L 1089.25,-281.71875 L 1089.25,-281.90625 C 1089.2835,-282.21131 1089.291,-282.50939 1089.3125,-282.8125 L 1089.3438,-283.0625 C 1089.367,-283.44867 1089.4029,-283.83818 1089.4062,-284.21875 L 1089.9688,-292.01164 C 1089.5375,-292.853 1089.0253,-293.61043 1088.4062,-294.23039 L 1060.3125,-321.8125 C 1057.3093,-324.81575 1053.3252,-326.252 1049.3125,-326.3125 z M 1084.4062,-270.0625 C 1084.0397,-269.63847 1083.657,-269.24582 1083.25,-268.875 C 1083.6571,-269.24538 1084.0399,-269.63783 1084.4062,-270.0625 z M 1079,-266.34375 C 1078.707,-266.24974 1078.3981,-266.19324 1078.0938,-266.125 C 1078.3983,-266.19141 1078.7069,-266.25151 1079,-266.34375 z M 1077.9375,-266.0625 C 1077.6397,-266.00077 1077.3398,-265.97343 1077.0312,-265.9375 C 1077.3347,-265.9716 1077.6445,-266.0034 1077.9375,-266.0625 z "
-           style="fill:url(#linearGradient2768);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5622)"
-           transform="matrix(-1,0,0,1,1984.8627,36.5)" />
-        <g
-           transform="translate(-204.63258,40.742641)"
-           id="g6245">
-          <path
-             style="opacity:1;fill:#1f1f1f;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871;filter:url(#filter5698)"
-             id="path6247"
-             d="M 1314.2336 -281.5 A 6.2335539 6.2335539 0 1 1  1301.7664,-281.5 A 6.2335539 6.2335539 0 1 1  1314.2336 -281.5 z"
-             transform="matrix(1.4081633,0,0,1.3269231,-724.50257,90.278845)" />
-          <path
-             transform="matrix(1.2649603,0,0,1.1919818,-537.19298,53.16998)"
-             d="M 1314.5 -281.5 A 6.5 6.5 0 1 1  1301.5,-281.5 A 6.5 6.5 0 1 1  1314.5 -281.5 z"
-             id="path6249"
-             style="opacity:1;fill:url(#linearGradient2770);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871" />
-        </g>
-        <path
-           style="fill:#3b3b3b;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871;filter:url(#filter5698)"
-           id="path6251"
-           d="M 1314.1105 -281.5 A 6.1104922 6.1104922 0 1 1  1301.8895,-281.5 A 6.1104922 6.1104922 0 1 1  1314.1105 -281.5 z"
-           transform="matrix(1.2040817,0,0,1.1346154,-662.19638,78.136871)" />
-        <path
-           transform="matrix(1.0816327,0,0,1.0192308,-502.03308,46.406102)"
-           d="M 1314.5 -281.5 A 6.5 6.5 0 1 1  1301.5,-281.5 A 6.5 6.5 0 1 1  1314.5 -281.5 z"
-           id="path6253"
-           style="fill:url(#linearGradient2772);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871" />
-        <path
-           transform="matrix(-1,0,0,1,2088.8627,36.5)"
-           clip-path="url(#clipPath5757)"
-           id="path6255"
-           d="M 1152.875,-323.8125 C 1149.9555,-323.85652 1147.0048,-323.1081 1144.4688,-321.65625 C 1140.85,-319.58462 1138.9029,-315.59111 1137.4688,-311.5 C 1128.0614,-311.03845 1116.078,-308.5605 1107.875,-294.40625 L 1108.7723,-294.06158 C 1116.653,-307.46902 1128.7996,-310.16145 1137.792,-310.60263 C 1139.1706,-314.53493 1141.2404,-318.39265 1144.7188,-320.38388 C 1150.2904,-323.57359 1157.8558,-322.83089 1162.6562,-318.03033 L 1188.1562,-292 C 1189.7365,-290.05686 1189.9873,-265.84374 1178.1562,-265.84375 L 1179.2812,-265.84375 C 1191.5902,-265.84374 1196.1134,-286.62691 1189.6875,-293.0625 L 1163.1562,-319.59375 C 1160.3469,-322.40313 1156.6287,-323.7559 1152.875,-323.8125 z "
-           style="opacity:0.82417585;fill:url(#linearGradient2774);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5753)" />
-        <rect
-           transform="matrix(0.7370101,0.6758817,-0.8422052,0.5391571,0,0)"
-           y="-826.4798"
-           x="298.58923"
-           height="10"
-           width="2.0691183"
-           id="rect6257"
-           style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871" />
-        <g
-           transform="matrix(-1,0,0,1,1977.0845,11.751263)"
-           id="g6259">
-          <path
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871;filter:url(#filter5698)"
-             id="path6261"
-             d="M 1314.1105 -281.5 A 6.1104922 6.1104922 0 1 1  1301.8895,-281.5 A 6.1104922 6.1104922 0 1 1  1314.1105 -281.5 z"
-             transform="matrix(0.2349258,0,0,0.2213724,740.7956,-231.71638)" />
-          <path
-             transform="matrix(0.2110351,0,0,0.19886,772.04472,-237.9073)"
-             d="M 1314.5 -281.5 A 6.5 6.5 0 1 1  1301.5,-281.5 A 6.5 6.5 0 1 1  1314.5 -281.5 z"
-             id="path6263"
-             style="opacity:1;fill:url(#linearGradient2776);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871" />
-          <rect
-             transform="matrix(0.7370101,0.6758817,-0.8422052,0.5391571,0,0)"
-             y="-957.89124"
-             x="328.35144"
-             height="1.951079"
-             width="0.40370131"
-             id="rect6265"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871" />
-        </g>
-        <g
-           id="g6267"
-           transform="matrix(-1,0,0,1,1994.7622,17.054564)">
-          <path
-             transform="matrix(0.2349258,0,0,0.2213724,740.7956,-231.71638)"
-             d="M 1314.1105 -281.5 A 6.1104922 6.1104922 0 1 1  1301.8895,-281.5 A 6.1104922 6.1104922 0 1 1  1314.1105 -281.5 z"
-             id="path6269"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871;filter:url(#filter5698)" />
-          <path
-             style="opacity:1;fill:url(#linearGradient2778);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871"
-             id="path6271"
-             d="M 1314.5 -281.5 A 6.5 6.5 0 1 1  1301.5,-281.5 A 6.5 6.5 0 1 1  1314.5 -281.5 z"
-             transform="matrix(0.2110351,0,0,0.19886,772.04472,-237.9073)" />
-          <rect
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871"
-             id="rect6273"
-             width="0.40370131"
-             height="1.951079"
-             x="328.35144"
-             y="-957.89124"
-             transform="matrix(0.7370101,0.6758817,-0.8422052,0.5391571,0,0)" />
-        </g>
-        <path
-           clip-path="url(#clipPath5917)"
-           id="path6275"
-           d="M 1040.125,-331.875 C 1035.6409,-331.6486 1030.5262,-330.90257 1025.5938,-328.4375 L 1024.9375,-326.65625 L 1033.0938,-311.8125 L 1040.125,-331.875 z "
-           style="fill:url(#linearGradient2780);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5911)"
-           transform="matrix(-1,0,0,1,1984.8627,36.5)" />
-        <path
-           clip-path="url(#clipPath5983)"
-           id="path6277"
-           d="M 1046.8867,-340.80107 C 1052.2341,-343.88841 1059.5378,-342.79045 1063.1631,-339.16517 L 1069.7793,-332.64529"
-           style="opacity:0.73260073;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#radialGradient2782);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5977)"
-           transform="matrix(-1,0,0,1,1984.8627,36.5)" />
-        <path
-           transform="matrix(-1.0093968,0,0,1.0109719,1995.0887,39.327692)"
-           style="opacity:0.58241763;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2784);stroke-width:0.59395117;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter6072)"
-           d="M 1088.25,-312.40625 L 1063.8438,-336.8125 C 1061.2601,-339.39616 1057.8584,-340.6667 1054.4062,-340.71875 C 1051.7213,-340.75923 1049.0198,-340.05396 1046.6875,-338.71875 C 1043.3595,-336.81356 1041.5376,-333.13742 1040.2188,-329.375 C 1031.5672,-328.95053 1020.5439,-326.67333 1013,-313.65625"
-           id="path6279" />
-        <path
-           id="path6281"
-           d="M 1037.5404,-321.53372 C 1040.5373,-324.57054 1044.6518,-326.13621 1048.4183,-325.96256"
-           style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:url(#radialGradient2786);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter6198)"
-           transform="matrix(-1,0,0,1,1984.8627,36.5)" />
-      </g>
-      <path
-         style="fill:url(#linearGradient2788);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 53.569377,48.146208 C 53.569377,48.146208 58.539021,44.39378 63.71586,44.39378 C 69.490295,44.39378 73.774895,48.320748 73.774895,48.320748 L 68.001907,53.99304 C 68.001907,53.99304 66.164985,52.596782 63.978268,52.509512 C 61.791488,52.422249 59.254978,53.643978 59.254978,53.643978 L 53.569377,48.146208 z "
-         id="path10217" />
-      <g
-         transform="matrix(0.6286128,-3.4784041e-2,3.4865234e-2,0.6271489,-601.12498,277.55429)"
-         id="g9023">
-        <path
-           style="opacity:1;fill:url(#linearGradient2790);fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           d="M 1008.2432,-293.5 C 995.64178,-293.5 985.05988,-286.92718 980.61818,-277.5 L 973.46198,-263 L 971.55568,-258.71875 C 970.50578,-255.7011 969.99428,-252.48284 970.11818,-249.125 C 970.73698,-232.358 986.92438,-218.74999 1006.2432,-218.75 C 1024.638,-218.75 1039.263,-231.09546 1040.087,-246.75 L 1040.1182,-247.5625 L 1040.1182,-266.53125 C 1040.1172,-266.56286 1040.1194,-266.59337 1040.1182,-266.625 C 1039.5723,-281.46 1025.2862,-293.50001 1008.2432,-293.5 z "
-           id="path6542" />
-        <rect
-           style="opacity:0.5677656;fill:url(#linearGradient2792);fill-opacity:1;stroke:none;stroke-width:3.79999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter7023)"
-           id="rect6989"
-           width="7.9257522"
-           height="28.852757"
-           x="758.11121"
-           y="-703.20679"
-           transform="matrix(0.8970666,0.4418954,-0.4418954,0.8970666,0,0)"
-           ry="0"
-           clip-path="url(#clipPath7001)" />
-        <path
-           transform="matrix(1.4140544,0,4.5293731e-2,1.2272727,-1138.9811,75.488636)"
-           d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-           id="path6544"
-           style="opacity:1;fill:#312f30;fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        <path
-           transform="matrix(1.3159007,0,4.2149759e-2,1.1414141,-990.15284,53.40404)"
-           d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-           id="path6567"
-           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.10063338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter6637)"
-           clip-path="url(#clipPath6641)" />
-        <path
-           style="opacity:0.71062275;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter6959)"
-           d="M 913.25,-314.25 C 906.90629,-314.25 891.57566,-300.82577 902.78125,-288.96875 C 922.47588,-293.1703 942.98977,-270.64172 952,-255.25 L 963.125,-260.78125 C 978.12397,-256.81286 965.8762,-274.84337 965.875,-274.875 C 965.32907,-289.71 930.293,-314.25001 913.25,-314.25 z "
-           id="path6645"
-           clip-path="url(#clipPath6965)"
-           transform="translate(88.9,-0.1)" />
-        <path
-           style="opacity:1;fill:url(#radialGradient2794);fill-opacity:1;stroke:none;stroke-width:1.25735915;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter7328)"
-           d="M 1524.75,-289.875 C 1510.7478,-289.875 1499.375,-278.50216 1499.375,-264.5 C 1499.375,-250.49784 1510.7478,-239.125 1524.75,-239.125 C 1538.7522,-239.125 1550.125,-250.49784 1550.125,-264.5 C 1550.125,-278.50216 1538.7522,-289.875 1524.75,-289.875 z M 1524.75,-288.625 C 1538.0718,-288.625 1548.875,-277.82184 1548.875,-264.5 C 1548.875,-251.17816 1537.9684,-241.72773 1524.6466,-241.72773 C 1511.3248,-241.72773 1500.625,-251.17816 1500.625,-264.5 C 1500.625,-277.82184 1511.4282,-288.625 1524.75,-288.625 z "
-           id="path7270"
-           transform="matrix(1.2045649,0,3.8583548e-2,1.0454545,-821.33676,29.897727)" />
-        <path
-           transform="matrix(1.1644308,0,3.7298007e-2,1.0106217,-760.48225,19.800556)"
-           id="path7338"
-           d="M 1524.75,-289.875 C 1510.7478,-289.875 1499.375,-278.50216 1499.375,-264.5 C 1499.375,-250.49784 1510.7478,-239.125 1524.75,-239.125 C 1538.7522,-239.125 1550.125,-250.49784 1550.125,-264.5 C 1550.125,-278.50216 1538.7522,-289.875 1524.75,-289.875 z M 1524.75,-288.625 C 1538.0718,-288.625 1548.875,-277.82184 1548.875,-264.5 C 1548.875,-251.17816 1537.7373,-246.36308 1524.4155,-246.36308 C 1511.0937,-246.36308 1500.625,-251.17816 1500.625,-264.5 C 1500.625,-277.82184 1511.4282,-288.625 1524.75,-288.625 z "
-           style="opacity:1;fill:url(#radialGradient2796);fill-opacity:1;stroke:none;stroke-width:1.25735915;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;" />
-        <path
-           style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:url(#linearGradient2798);stroke-width:1.33052707;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter7845)"
-           d="M 1021.25,-275.25 C 1015.275,-279.38684 1000.1752,-280.67307 992.5,-277.75"
-           id="path7342"
-           transform="matrix(1.0071784,6.6649744e-3,-2.0689432e-3,1.099251,-7.4728276,20.969158)" />
-        <path
-           transform="matrix(1.1054471,0,3.5408698e-2,0.9594292,-671.04679,3.5391823)"
-           d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-           id="path7486"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        <path
-           style="opacity:1;fill:url(#radialGradient2800);fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="path7396"
-           d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-           transform="matrix(1.1054471,0,3.5408698e-2,0.9594292,-671.04679,3.5391823)" />
-        <path
-           transform="matrix(1.1439104,0,3.6640722e-2,0.9929096,-729.36791,12.670971)"
-           d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-           id="path7400"
-           style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient2802);stroke-width:1.00305974;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;" />
-        <path
-           style="opacity:1;fill:url(#radialGradient2804);fill-opacity:1;stroke:none;stroke-width:1.39999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter8002)"
-           id="path7972"
-           d="M 1025 -231.96094 A 19.921875 8.0078125 0 1 1  985.15625,-231.96094 A 19.921875 8.0078125 0 1 1  1025 -231.96094 z" />
-        <g
-           id="g8993"
-           clip-path="url(#clipPath8998)"
-           transform="translate(138.99076,0)">
-          <path
-             transform="matrix(0.9556737,0,0,0.9556737,-96.019518,-10.419438)"
-             id="path7849"
-             d="M 979.03241,-261.5 C 978.95101,-260.62063 978.90531,-259.71814 978.93871,-258.8125 C 979.42251,-245.70478 992.08611,-235.06251 1007.1887,-235.0625 C 1022.2913,-235.0625 1034.1412,-245.70478 1033.6574,-258.8125 C 1033.6423,-259.22212 1033.6335,-259.62671 1033.595,-260.03125 C 1032.481,-248.19766 1021.6265,-237.79687 1007.5793,-237.79687 C 992.94874,-237.79688 980.22851,-248.95915 979.03241,-261.5 z "
-             style="opacity:0.85714285;fill:url(#linearGradient2806);fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter7958)" />
-          <path
-             style="opacity:1;fill:url(#linearGradient2808);fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter7958)"
-             d="M 979.03241,-261.5 C 978.95101,-260.62063 978.90531,-259.71814 978.93871,-258.8125 C 979.42251,-245.70478 992.08611,-235.06251 1007.1887,-235.0625 C 1022.2913,-235.0625 1034.1412,-245.70478 1033.6574,-258.8125 C 1033.6423,-259.22212 1033.6335,-259.62671 1033.595,-260.03125 C 1032.481,-248.19766 1019.5828,-236.97938 1005.5356,-236.97938 C 990.90502,-236.97939 980.22851,-248.95915 979.03241,-261.5 z "
-             id="path8979"
-             transform="matrix(0.9556737,0,0,0.9556737,-93.285143,-23.310063)" />
-          <path
-             transform="matrix(1.0245758,0,0,1.0431674,-162.62139,-0.3998272)"
-             id="path8983"
-             d="M 979.03241,-261.5 C 978.95101,-260.62063 978.90531,-259.71814 978.93871,-258.8125 C 979.42251,-245.70478 991.14255,-235.45968 1006.2451,-235.45968 C 1021.3477,-235.45967 1034.1412,-245.70478 1033.6574,-258.8125 C 1033.6423,-259.22212 1033.6335,-259.62671 1033.595,-260.03125 C 1032.481,-248.19766 1023.587,-236.97938 1005.5356,-236.97938 C 990.90502,-236.97938 980.22851,-248.95915 979.03241,-261.5 z "
-             style="opacity:0.37362641;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        </g>
-        <path
-           style="opacity:1;fill:url(#radialGradient2810);fill-opacity:1;stroke:none;stroke-width:1.39999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="path7962"
-           d="M 1034.1437 -242.67863 A 4.9718447 4.9718447 0 1 1  1024.2,-242.67863 A 4.9718447 4.9718447 0 1 1  1034.1437 -242.67863 z"
-           transform="translate(-5.8004853,-7.1815533)" />
-        <path
-           style="opacity:1;fill:url(#linearGradient2812);fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           d="M 1003.8594,-273.96875 C 994.8747,-273.96875 987.00892,-270.21641 982.23438,-264.40625 C 985.20603,-258.18825 994.51069,-253.65625 1005.4844,-253.65625 C 1015.3749,-253.65625 1023.8809,-257.31327 1027.6406,-262.59375 C 1022.5807,-269.4177 1013.7441,-273.96875 1003.8594,-273.96875 z "
-           id="path9008" />
-      </g>
-      <path
-         style="opacity:0.71062275;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter6959)"
-         d="M 913.25,-314.25 C 906.90629,-314.25 891.57566,-300.82577 902.78125,-288.96875 C 922.47588,-293.1703 942.98977,-270.64172 952,-255.25 L 963.125,-260.78125 C 978.12397,-256.81286 965.8762,-274.84337 965.875,-274.875 C 965.32907,-289.71 930.293,-314.25001 913.25,-314.25 z "
-         id="path9053"
-         clip-path="url(#clipPath6965)"
-         transform="matrix(-0.6284252,-3.8009559e-2,-3.8098281e-2,0.6269617,672.29223,277.36684)" />
-      <path
-         style="fill:url(#linearGradient2814);fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="M 105.73195,58.47244 C 113.65099,58.951414 120.05051,63.474533 122.48262,69.553841 L 126.42733,78.91679 L 127.46219,81.673427 C 128.00701,83.605284 128.20584,85.642452 128.00005,87.74298 C 126.97239,98.231726 116.28137,106.14815 104.14095,105.41385 C 92.581198,104.71467 83.86082,96.418647 83.939409,86.572531 L 83.950757,86.061938 L 84.673434,74.169259 C 84.675266,74.149478 84.675046,74.130266 84.677005,74.110481 C 85.585251,64.830253 95.021699,57.824637 105.73195,58.47244 z "
-         id="path9045" />
-      <rect
-         style="opacity:0.5677656;fill:url(#linearGradient2816);fill-opacity:1;stroke:none;stroke-width:3.79999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter7023)"
-         id="rect9047"
-         width="7.9257522"
-         height="28.852757"
-         x="758.11121"
-         y="-703.20679"
-         transform="matrix(-0.5805747,0.2429544,0.2435215,0.5792226,728.15554,280.80858)"
-         ry="0"
-         clip-path="url(#clipPath7001)" />
-      <path
-         transform="matrix(-0.8886274,-5.3747584e-2,-7.5220702e-2,0.7677314,1441.044,371.42923)"
-         d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-         id="path9049"
-         style="fill:#312f30;fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         transform="matrix(-0.8269452,-5.0016805e-2,-6.9973886e-2,0.7140208,1348.3579,351.92614)"
-         d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-         id="path9051"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.10063338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter6637)"
-         clip-path="url(#clipPath6641)" />
-      <path
-         style="fill:url(#radialGradient2818);fill-opacity:1;stroke:none;stroke-width:1.25735915;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter3606)"
-         d="M 1524.75,-289.875 C 1510.7478,-289.875 1499.375,-278.50216 1499.375,-264.5 C 1499.375,-250.49784 1510.7478,-239.125 1524.75,-239.125 C 1538.7522,-239.125 1550.125,-250.49784 1550.125,-264.5 C 1550.125,-278.50216 1538.7522,-289.875 1524.75,-289.875 z M 1524.75,-288.625 C 1538.0718,-288.625 1548.875,-277.82184 1548.875,-264.5 C 1548.875,-251.17816 1537.9684,-241.72773 1524.6466,-241.72773 C 1511.3248,-241.72773 1500.625,-251.17816 1500.625,-264.5 C 1500.625,-277.82184 1511.4282,-288.625 1524.75,-288.625 z "
-         id="path9055"
-         transform="matrix(-0.7569789,-4.5784981e-2,-6.4076893e-2,0.6539934,1243.1652,330.77196)" />
-      <path
-         transform="matrix(-0.7317577,-4.4259501e-2,-6.1941957e-2,0.6322034,1205.3074,322.12836)"
-         id="path9057"
-         d="M 1524.75,-289.875 C 1510.7478,-289.875 1499.375,-278.50216 1499.375,-264.5 C 1499.375,-250.49784 1510.7478,-239.125 1524.75,-239.125 C 1538.7522,-239.125 1550.125,-250.49784 1550.125,-264.5 C 1550.125,-278.50216 1538.7522,-289.875 1524.75,-289.875 z M 1524.75,-288.625 C 1538.0718,-288.625 1548.875,-277.82184 1548.875,-264.5 C 1548.875,-251.17816 1537.7373,-246.36308 1524.4155,-246.36308 C 1511.0937,-246.36308 1500.625,-251.17816 1500.625,-264.5 C 1500.625,-277.82184 1511.4282,-288.625 1524.75,-288.625 z "
-         style="fill:url(#radialGradient2820);fill-opacity:1;stroke:none;stroke-width:1.25735915;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;" />
-      <path
-         style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:url(#linearGradient2822);stroke-width:1.33052707;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter7845)"
-         d="M 1021.25,-275.25 C 1015.275,-279.38684 1000.1752,-280.67307 992.5,-277.75"
-         id="path9059"
-         transform="matrix(-0.6331902,-3.4103723e-2,-4.0579397e-2,0.6892669,732.05275,294.23947)" />
-      <path
-         transform="matrix(-0.6946908,-4.2017557e-2,-5.8804321e-2,0.6001795,1149.7234,308.5337)"
-         d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-         id="path9061"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         style="fill:url(#radialGradient2824);fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="path9063"
-         d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-         transform="matrix(-0.6946908,-4.2017557e-2,-5.8804321e-2,0.6001795,1149.7234,308.5337)" />
-      <path
-         transform="matrix(-0.7188621,-4.347953e-2,-6.0854102e-2,0.6211236,1186.026,316.47574)"
-         d="M 1549.5 -264.5 A 24.75 24.75 0 1 1  1500,-264.5 A 24.75 24.75 0 1 1  1549.5 -264.5 z"
-         id="path9065"
-         style="fill:none;fill-opacity:1;stroke:url(#linearGradient2826);stroke-width:1.00305974;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;" />
-      <path
-         transform="matrix(-0.6284252,-3.8009559e-2,-3.8098281e-2,0.6269617,728.15554,280.80858)"
-         style="fill:url(#radialGradient2828);fill-opacity:1;stroke:none;stroke-width:1.39999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter8002)"
-         id="path9067"
-         d="M 1025 -231.96094 A 19.921875 8.0078125 0 1 1  985.15625,-231.96094 A 19.921875 8.0078125 0 1 1  1025 -231.96094 z" />
-      <g
-         id="g9069"
-         clip-path="url(#clipPath8998)"
-         transform="matrix(-0.6284252,-3.8009559e-2,-3.8098281e-2,0.6269617,640.81022,275.5256)">
-        <path
-           transform="matrix(0.9556737,0,0,0.9556737,-96.019518,-10.419438)"
-           id="path9071"
-           d="M 979.03241,-261.5 C 978.95101,-260.62063 978.90531,-259.71814 978.93871,-258.8125 C 979.42251,-245.70478 992.08611,-235.06251 1007.1887,-235.0625 C 1022.2913,-235.0625 1034.1412,-245.70478 1033.6574,-258.8125 C 1033.6423,-259.22212 1033.6335,-259.62671 1033.595,-260.03125 C 1032.481,-248.19766 1021.6265,-237.79687 1007.5793,-237.79687 C 992.94874,-237.79688 980.22851,-248.95915 979.03241,-261.5 z "
-           style="opacity:0.85714285;fill:url(#linearGradient2830);fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter7958)" />
-        <path
-           style="opacity:1;fill:url(#linearGradient2832);fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter7958)"
-           d="M 979.03241,-261.5 C 978.95101,-260.62063 978.90531,-259.71814 978.93871,-258.8125 C 979.42251,-245.70478 992.08611,-235.06251 1007.1887,-235.0625 C 1022.2913,-235.0625 1034.1412,-245.70478 1033.6574,-258.8125 C 1033.6423,-259.22212 1033.6335,-259.62671 1033.595,-260.03125 C 1032.481,-248.19766 1019.5828,-236.97938 1005.5356,-236.97938 C 990.90502,-236.97939 980.22851,-248.95915 979.03241,-261.5 z "
-           id="path9073"
-           transform="matrix(0.9556737,0,0,0.9556737,-93.285143,-23.310063)" />
-        <path
-           transform="matrix(1.0245758,0,0,1.0431674,-162.62139,-0.3998272)"
-           id="path9075"
-           d="M 979.03241,-261.5 C 978.95101,-260.62063 978.90531,-259.71814 978.93871,-258.8125 C 979.42251,-245.70478 991.14255,-235.45968 1006.2451,-235.45968 C 1021.3477,-235.45967 1034.1412,-245.70478 1033.6574,-258.8125 C 1033.6423,-259.22212 1033.6335,-259.62671 1033.595,-260.03125 C 1032.481,-248.19766 1023.587,-236.97938 1005.5356,-236.97938 C 990.90502,-236.97938 980.22851,-248.95915 979.03241,-261.5 z "
-           style="opacity:0.37362641;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      </g>
-      <path
-         style="opacity:0.64835169;fill:url(#radialGradient2834);fill-opacity:1;stroke:none;stroke-width:1.39999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="path9077"
-         d="M 1034.1437 -242.67863 A 4.9718447 4.9718447 0 1 1  1024.2,-242.67863 A 4.9718447 4.9718447 0 1 1  1034.1437 -242.67863 z"
-         transform="matrix(-0.6284252,-3.8009559e-2,-3.8098281e-2,0.6269617,754.65835,277.89246)" />
-      <path
-         style="fill:url(#linearGradient2836);fill-opacity:1;stroke:none;stroke-width:0.4554573;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="M 107.74273,70.884412 C 113.38895,71.225916 118.18905,73.877465 120.96811,77.70169 C 118.86379,81.487188 112.84382,83.974911 105.94767,83.557806 C 99.732231,83.181872 94.526173,80.565752 92.36466,77.112188 C 95.804409,73.026158 101.53094,70.508699 107.74273,70.884412 z "
-         id="path9079" />
-      <path
-         clip-path="url(#clipPath10259)"
-         style="fill:url(#linearGradient2838);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871;filter:url(#filter10253)"
-         id="path10221"
-         d="M 1314.1105 -281.5 A 6.1104922 6.1104922 0 1 1  1301.8895,-281.5 A 6.1104922 6.1104922 0 1 1  1314.1105 -281.5 z"
-         transform="matrix(0.7398573,-4.0622272e-2,3.866785e-2,0.6901565,-893.29723,296.25235)" />
-      <path
-         id="rect10165"
-         d="M 60.346038,47.304844 C 60.456907,46.584763 61.42413,45.610673 63.724359,45.610673 C 66.027736,45.610673 67.057224,46.566045 67.045136,47.304844 L 67.939705,54.980295 L 59.357348,54.980295 L 60.346038,47.304844 z "
-         style="fill:url(#linearGradient2840);fill-opacity:1;stroke:none;stroke-width:1.39999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         id="path9180"
-         d="M 51.002332,56.709219 C 51.002332,56.709219 57.159424,52.060242 63.573071,52.060242 C 70.727165,52.060242 76.03546,56.925447 76.03546,56.925447 L 68.883192,63.95298 C 68.883192,63.95298 66.60739,62.223126 63.898186,62.115009 C 61.188919,62.006892 58.046313,63.520512 58.046313,63.520512 L 51.002332,56.709219 z "
-         style="fill:url(#linearGradient2842);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <path
-         transform="matrix(0.943356,-5.2200234e-2,4.9303496e-2,0.8868615,-1156.0774,375.18063)"
-         d="M 1314.1105 -281.5 A 6.1104922 6.1104922 0 1 1  1301.8895,-281.5 A 6.1104922 6.1104922 0 1 1  1314.1105 -281.5 z"
-         id="path10207"
-         style="fill:#3b3b3b;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871;filter:url(#filter5698)" />
-      <path
-         style="fill:url(#linearGradient2844);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871"
-         id="path10209"
-         d="M 1314.5 -281.5 A 6.5 6.5 0 1 1  1301.5,-281.5 A 6.5 6.5 0 1 1  1314.5 -281.5 z"
-         transform="matrix(0.8474214,-4.6891735e-2,4.4289582e-2,0.7966722,-1031.9739,343.43506)" />
-      <path
-         style="fill:url(#linearGradient2846);fill-opacity:1;stroke:none;stroke-width:1.39999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
-         d="M 60.346038,47.304844 C 60.456907,46.584763 61.42413,45.610673 63.724359,45.610673 C 66.027736,45.610673 67.057224,46.566045 67.045136,47.304844 L 67.939705,54.980295 L 59.357348,54.980295 L 60.346038,47.304844 z "
-         id="path10265" />
-      <g
-         id="g10279"
-         transform="matrix(0.6286128,-3.4784041e-2,3.4865234e-2,0.6271489,-602.50478,302.32967)">
-        <path
-           transform="matrix(0.2349258,0,0,0.2213724,740.7956,-231.71638)"
-           d="M 1314.1105 -281.5 A 6.1104922 6.1104922 0 1 1  1301.8895,-281.5 A 6.1104922 6.1104922 0 1 1  1314.1105 -281.5 z"
-           id="path10281"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871;filter:url(#filter5698)" />
-        <path
-           style="opacity:1;fill:url(#linearGradient2848);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871"
-           id="path10283"
-           d="M 1314.5 -281.5 A 6.5 6.5 0 1 1  1301.5,-281.5 A 6.5 6.5 0 1 1  1314.5 -281.5 z"
-           transform="matrix(0.2110351,0,0,0.19886,772.04472,-237.9073)" />
-        <rect
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871"
-           id="rect10285"
-           width="0.40370131"
-           height="1.951079"
-           x="328.35144"
-           y="-957.89124"
-           transform="matrix(0.7370101,0.6758817,-0.8422052,0.5391571,0,0)" />
-      </g>
-      <g
-         transform="matrix(0.6286128,-3.4784041e-2,3.4865234e-2,0.6271489,-566.23021,302.45235)"
-         id="g10289">
-        <path
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871;filter:url(#filter5698)"
-           id="path10291"
-           d="M 1314.1105 -281.5 A 6.1104922 6.1104922 0 1 1  1301.8895,-281.5 A 6.1104922 6.1104922 0 1 1  1314.1105 -281.5 z"
-           transform="matrix(0.2349258,0,0,0.2213724,740.7956,-231.71638)" />
-        <path
-           transform="matrix(0.2110351,0,0,0.19886,772.04472,-237.9073)"
-           d="M 1314.5 -281.5 A 6.5 6.5 0 1 1  1301.5,-281.5 A 6.5 6.5 0 1 1  1314.5 -281.5 z"
-           id="path10293"
-           style="opacity:1;fill:url(#linearGradient2850);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871" />
-        <rect
-           transform="matrix(0.7370101,0.6758817,-0.8422052,0.5391571,0,0)"
-           y="-957.89124"
-           x="328.35144"
-           height="1.951079"
-           width="0.40370131"
-           id="rect10295"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871" />
-      </g>
-      <path
-         transform="matrix(0.8474214,-4.6891735e-2,4.4289582e-2,0.7966722,-1031.9739,343.43506)"
-         d="M 1314.5 -281.5 A 6.5 6.5 0 1 1  1301.5,-281.5 A 6.5 6.5 0 1 1  1314.5 -281.5 z"
-         id="path11198"
-         style="opacity:0.35531138;fill:url(#linearGradient2852);fill-opacity:1;stroke:none;stroke-width:0.271;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35483871" />
+<svg version="1.0" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <linearGradient id="linearGradient10959">
+   <stop offset="0"/>
+   <stop stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient9182">
+   <stop stop-color="#3a3a3c" offset="0"/>
+   <stop stop-color="#5d5d60" offset=".5"/>
+   <stop stop-color="#97989b" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient9015">
+   <stop stop-color="#fff" offset="0"/>
+   <stop stop-color="#fff" stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient7974">
+   <stop stop-color="#a04e21" offset="0"/>
+   <stop stop-color="#a04e21" stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient7964">
+   <stop stop-color="#fff0c3" offset="0"/>
+   <stop stop-color="#c13d00" stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient7866">
+   <stop stop-color="#f4bea0" offset="0"/>
+   <stop stop-color="#e5702f" stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient7488">
+   <stop stop-color="#eb7331" offset="0"/>
+   <stop stop-color="#eb7331" stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient5991">
+   <stop stop-opacity="0" offset="0"/>
+   <stop stop-opacity=".68327" offset=".25"/>
+   <stop offset=".5"/>
+   <stop stop-opacity=".72954" offset=".75"/>
+   <stop stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient5595">
+   <stop stop-color="#dddbdc" offset="0"/>
+   <stop stop-color="#878485" offset=".74324"/>
+   <stop stop-color="#4e4c4d" offset=".80917"/>
+   <stop stop-color="#2e2c2d" offset="1"/>
+  </linearGradient>
+  <filter id="filter5622">
+   <feGaussianBlur stdDeviation="0.3713333"/>
+  </filter>
+  <filter id="filter5698">
+   <feGaussianBlur stdDeviation="0.26202037"/>
+  </filter>
+  <filter id="filter5753">
+   <feGaussianBlur stdDeviation="1.4374244"/>
+  </filter>
+  <clipPath id="clipPath5757">
+   <path d="m1165.6-265.86h14.142c12.521 0 17.134-21.128 10.597-27.674l-26.994-26.994c-5.0806-5.0806-13.106-5.4829-19.003-2.1071-3.6812 2.1074-5.6787 6.1876-7.1376 10.349-9.5696.4695-21.758 2.9813-30.103 17.38l58.497 29.046z" fill="#3d3b3c" fill-rule="evenodd"/>
+  </clipPath>
+  <filter id="filter5911" x="-.11477" y="-.086885" width="1.2295" height="1.1738">
+   <feGaussianBlur stdDeviation="0.87156593"/>
+  </filter>
+  <linearGradient id="linearGradient5921" x1="1320.7" x2="1380.6" y1="-304.53" y2="-304.53" gradientTransform="translate(-317.5)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5595"/>
+  <clipPath id="clipPath5917">
+   <path d="m1054.4-343.22c-2.6849-.04048-5.3864.66479-7.7187 2-3.328 1.9052-5.1499 5.5813-6.4687 9.3438-8.6516.42447-19.675 2.7017-27.219 15.719l-9.6875 20.938h.0937c-.0626.10604-.1253.20514-.1874.3125l58.5 29.062h14.125c7.7637 1e-5 12.466-8.1381 13.375-15.875h.0312v-.1875c.0335-.30506.041-.60314.0625-.90625l.0313-.25c.0232-.38617.0589-.77568.0624-1.1562l1.3438-19.812c.5471-4.3506-.2204-8.592-2.5-10.875l-24.406-24.406c-2.5837-2.5837-5.9854-3.8542-9.4376-3.9062z" fill="url(#linearGradient5921)" fill-rule="evenodd"/>
+  </clipPath>
+  <filter id="filter5977">
+   <feGaussianBlur stdDeviation="0.27275091"/>
+  </filter>
+  <clipPath id="clipPath5983">
+   <path d="m1054.4-343.22c-2.6849-.04048-5.3864.66479-7.7187 2-3.328 1.9052-5.1499 5.5813-6.4687 9.3438-8.6516.42447-19.675 2.7017-27.219 15.719l-9.6875 20.938h.0937c-.0626.10604-.1253.20514-.1874.3125l58.5 29.062h14.125c7.7637 1e-5 12.466-8.1381 13.375-15.875h.0312v-.1875c.0335-.30506.041-.60314.0625-.90625l.0313-.25c.0232-.38617.0589-.77568.0624-1.1562l1.3438-19.812c.5471-4.3506-.2204-8.592-2.5-10.875l-24.406-24.406c-2.5837-2.5837-5.9854-3.8542-9.4376-3.9062z" fill="url(#linearGradient5921)" fill-rule="evenodd"/>
+  </clipPath>
+  <filter id="filter6035">
+   <feGaussianBlur stdDeviation="1.0516022"/>
+  </filter>
+  <linearGradient id="linearGradient6054" x1="1320.7" x2="1380.6" y1="-304.53" y2="-304.53" gradientTransform="matrix(.93997 -.34126 .34126 .93997 -245.88 186.61)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5595"/>
+  <clipPath id="clipPath6050">
+   <path d="m926.54-604.18c-2.5375.87821-4.8362 2.4631-6.5728 4.514-2.478 2.9265-2.936 7.0037-2.8917 10.99-7.9874 3.3515-17.572 9.2538-20.221 24.064l-1.9607 22.987.08808-.03196c-.02265.12103-.04777.23558-.06951.35769l64.906 7.3539 13.277-4.8204c7.2976-2.6494 8.9402-11.904 7.1545-19.486l.02933-.01065-.06399-.17624c-.07261-.29818-.16729-.58093-.25052-.87318l-.05589-.24567c-.10998-.37091-.20935-.74922-.33594-1.1081l-5.4982-19.082c-.97043-4.2761-3.1393-8.001-6.0612-9.369l-31.27-14.612c-3.3103-1.5468-6.9414-1.5802-10.204-.45105z" fill="url(#linearGradient6054)" fill-rule="evenodd"/>
+  </clipPath>
+  <filter id="filter6072">
+   <feGaussianBlur stdDeviation="0.083138439"/>
+  </filter>
+  <filter id="filter6198" x="-.11233" y="-.22652" width="1.2247" height="1.453">
+   <feGaussianBlur stdDeviation="0.4135875"/>
+  </filter>
+  <filter id="filter6637">
+   <feGaussianBlur stdDeviation="0.77462889"/>
+  </filter>
+  <clipPath id="clipPath6641">
+   <path transform="matrix(1.0731 0 -2.0618e-5 1.0737 -111.42 18.59)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5401"/>
+  </clipPath>
+  <filter id="filter6959" x="-.10593" y="-.14073" width="1.2119" height="1.2815">
+   <feGaussianBlur stdDeviation="3.802569"/>
+  </filter>
+  <linearGradient id="linearGradient6969" x1="1342.2" x2="1379.2" y1="-271.97" y2="-258.92" gradientTransform="translate(-445.13)" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient5595"/>
+  <clipPath id="clipPath6965">
+   <path d="m919.49-293.5c-12.601 0-23.183 6.5728-27.625 16l-7.1562 14.5-1.9063 4.2812c-1.0499 3.0176-1.5614 6.2359-1.4375 9.5938.6188 16.767 16.806 30.375 36.125 30.375 18.395 0 33.02-12.345 33.844-28l.0312-.8125v-18.969c-.001-.03161.0012-.06212 0-.09375-.5459-14.835-14.832-26.875-31.875-26.875z" fill="url(#linearGradient6969)"/>
+  </clipPath>
+  <linearGradient id="linearGradient7005" x1="1342.2" x2="1379.2" y1="-271.97" y2="-258.92" gradientTransform="matrix(.89707 -.4419 .4419 .89707 -319.7 157.48)" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient5595"/>
+  <clipPath id="clipPath7001">
+   <path d="m774.76-708.83c-11.304 5.5685-17.892 16.141-17.711 26.56l-.0121 16.17.18178 4.683c.39166 3.171 1.3549 6.284 2.9499 9.2415 7.9644 14.768 28.499 19.822 45.829 11.285 16.501-8.1286 24.166-25.666 17.987-40.073l-.33105-.74266-8.3822-17.016c-.01486-.02791-.02637-.05626-.04143-.0841-7.0452-13.067-25.181-17.554-40.47-10.023z" fill="url(#linearGradient7005)"/>
+  </clipPath>
+  <filter id="filter7023">
+   <feGaussianBlur stdDeviation="0.60163542"/>
+  </filter>
+  <filter id="filter7256" x="-.1955" y="-.091377" width="1.391" height="1.1828">
+   <feGaussianBlur stdDeviation="0.90989293"/>
+  </filter>
+  <linearGradient id="linearGradient7266" x1="1320.7" x2="1395.6" y1="-304.53" y2="-307.28" gradientTransform="matrix(.99069 0 0 .98915 -304.41 -2.797)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5595"/>
+  <clipPath id="clipPath7262">
+   <path d="m1054.7-342.29c-2.6599-.04004-5.3362.65757-7.6468 1.9783-3.297 1.8845-5.102 5.5208-6.4085 9.2424-8.5711.41986-19.492 2.6724-26.965 15.548l-9.5973 20.71h.0928c-.062.10489-.1241.20292-.1857.30911l57.956 28.747h13.994c7.6914 1e-5 12.35-8.0498 13.25-15.703h.031v-.18546c.0331-.30175.0406-.5966.0619-.89642l.031-.24729c.023-.38198.0583-.76726.0618-1.1437l1.3313-19.597c.542-4.3034-.2184-8.4988-2.4767-10.757l-24.179-24.141c-2.5597-2.5556-5.9297-3.8124-9.3498-3.8639z" fill="url(#linearGradient7266)" fill-rule="evenodd"/>
+  </clipPath>
+  <filter id="filter7328">
+   <feGaussianBlur stdDeviation="0.37286051"/>
+  </filter>
+  <filter id="filter7845">
+   <feGaussianBlur stdDeviation="0.26782521"/>
+  </filter>
+  <filter id="filter7958">
+   <feGaussianBlur stdDeviation="0.37171029"/>
+  </filter>
+  <filter id="filter8002" x="-.041083" y="-.10221" width="1.0822" height="1.2044">
+   <feGaussianBlur stdDeviation="0.81845238"/>
+  </filter>
+  <radialGradient id="radialGradient9002" cx="1524.2" cy="-260.48" r="24.75" fx="1521.6" fy="-250.72" gradientTransform="matrix(1.3105 .1241 -.054104 1.689 -487.04 -8.4188)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7488"/>
+  <clipPath id="clipPath8998">
+   <path transform="matrix(1.1054 0 .035409 .95943 -810.11 3.5392)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z" fill="url(#radialGradient9002)"/>
+  </clipPath>
+  <filter id="filter10253" x="-.16129" y="-.16124" width="1.3226" height="1.3225">
+   <feGaussianBlur stdDeviation="0.98542663"/>
+  </filter>
+  <linearGradient id="linearGradient10263" x1="1587.5" x2="1626.3" y1="-287.56" y2="-275.46" gradientTransform="matrix(.85342 .050232 -.047704 .91274 -73.971 -100.06)" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient9182"/>
+  <clipPath id="clipPath10259">
+   <path d="m1294.6-283.29s6.9797-5.0262 13.955-4.6157c7.7808.45797 13.258 6.4703 13.258 6.4703l-8.2071 7.7358s-2.3698-2.1626-5.3097-2.4621c-2.9401-.29949-6.4502 1.2641-6.4502 1.2641l-7.246-8.3925z" fill="url(#linearGradient10263)" fill-rule="evenodd"/>
+  </clipPath>
+  <radialGradient id="radialGradient10965" cx="64" cy="122" r="64" fx="23.043" gradientTransform="matrix(1 0 0 .09375 0 110.56)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient10959"/>
+  <linearGradient id="linearGradient2724" x1="1342.2" x2="1379.2" y1="-271.97" y2="-258.92" gradientTransform="matrix(-.24944 -.015366 -.015122 .25345 421.16 124.52)" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient5595"/>
+  <linearGradient id="linearGradient2726" x1="758.88" x2="765.16" y1="-688.43" y2="-688.52" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5991"/>
+  <linearGradient id="linearGradient2728" x1="1006.9" x2="1021.9" y1="-277.2" y2="-277.29" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient9015" spreadMethod="reflect"/>
+  <linearGradient id="linearGradient2736" x1="1320.7" x2="1395.6" y1="-304.53" y2="-307.28" gradientTransform="matrix(.62861 -.034784 .034865 .62715 -812.72 299.32)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5595"/>
+  <linearGradient id="linearGradient2738" x1="924.29" x2="940.11" y1="-593.1" y2="-593.1" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5991"/>
+  <linearGradient id="linearGradient2740" x1="1050.3" x2="1053.8" y1="-359.13" y2="-304.63" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient9015"/>
+  <linearGradient id="linearGradient2742" x1="1308" x2="1315.7" y1="-275" y2="-297.2" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5595"/>
+  <radialGradient id="radialGradient2746" cx="1039.5" cy="-288.62" r="43.099" fx="1057.8" fy="-298.02" gradientTransform="matrix(.40669 .34072 -.2269 .26957 -458.07 -206.6)" gradientUnits="userSpaceOnUse">
+   <stop offset="0"/>
+   <stop stop-opacity="0" offset="1"/>
+  </radialGradient>
+  <linearGradient id="linearGradient2748" x1="1143.4" x2="1150.2" y1="-320.31" y2="-265.86" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient10959"/>
+  <linearGradient id="linearGradient2754" x1="1043.1" x2="1024.2" y1="-326.56" y2="-321.84" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient10959"/>
+  <radialGradient id="radialGradient2756" cx="1058" cy="-345.89" r="11.965" gradientTransform="matrix(1 0 0 .46555 .28033 -180.87)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient9015"/>
+  <linearGradient id="linearGradient2758" x1="1040.7" x2="1051.4" y1="-346.51" y2="-306.53" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient10959"/>
+  <radialGradient id="radialGradient2760" cx="1041.8" cy="-325.97" r="5.6265" gradientTransform="matrix(1.2777 .022216 -.0069657 .40061 -291.86 -217.51)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient9015"/>
+  <linearGradient id="linearGradient2762" x1="990.33" x2="1000.7" y1="-289.28" y2="-309.96" gradientTransform="translate(.25 .25)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient10959"/>
+  <linearGradient id="linearGradient2764" x1="1320.7" x2="1395.6" y1="-304.53" y2="-307.28" gradientTransform="matrix(-1 0 0 1 2302.4 36.5)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5595"/>
+  <linearGradient id="linearGradient2780" x1="1044.4" x2="1029.3" y1="-328.56" y2="-323.61" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient10959"/>
+  <radialGradient id="radialGradient2786" cx="1041.8" cy="-325.97" r="5.6265" gradientTransform="matrix(1.3444 0 0 .40067 -359.14 -194.32)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient9015"/>
+  <linearGradient id="linearGradient2788" x1="1587.5" x2="1626.3" y1="-287.56" y2="-275.46" gradientTransform="matrix(.63335 0 0 .63187 -951.89 230.2)" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient9182"/>
+  <linearGradient id="linearGradient2790" x1="1342.2" x2="1379.2" y1="-271.97" y2="-258.92" gradientTransform="translate(-356.38)" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient5595"/>
+  <radialGradient id="radialGradient2794" cx="1523.9" cy="-239.08" r="25.379" fx="1530.7" fy="-239.92" gradientTransform="matrix(1.5767 -.34694 .23734 1.1836 -822.12 572.61)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient9015"/>
+  <radialGradient id="radialGradient2796" cx="1523.9" cy="-239.08" r="25.379" fx="1520.8" fy="-241.94" gradientTransform="matrix(1.5767 -.34694 .23734 1.1836 -822.12 572.61)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient10959"/>
+  <linearGradient id="linearGradient2802" x1="1514.1" x2="1527.5" y1="-288.7" y2="-257.33" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient9015"/>
+  <radialGradient id="radialGradient2804" cx="1005.1" cy="-231.96" r="19.922" fx="1003.9" fy="-217.38" gradientTransform="matrix(.99834 .057597 -.029412 .5098 -5.1539 -171.6)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7974"/>
+  <linearGradient id="linearGradient2806" x1="1191" x2="1218.4" y1="-239.69" y2="-239.69" gradientTransform="translate(-184.75 -8.5938)" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient7866"/>
+  <radialGradient id="radialGradient2810" cx="1029.2" cy="-242.68" r="4.9718" fx="1028.6" fy="-244.89" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7964"/>
+  <linearGradient id="linearGradient2812" x1="941.54" x2="905.31" y1="-297.18" y2="-260.96" gradientTransform="translate(90.234)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient9015"/>
+  <linearGradient id="linearGradient2814" x1="1342.2" x2="1379.2" y1="-271.97" y2="-258.92" gradientTransform="matrix(-.62843 -.03801 -.038098 .62696 952.11 294.35)" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient5595"/>
+  <radialGradient id="radialGradient2818" cx="1523.9" cy="-239.08" r="25.379" fx="1517.7" fy="-243.73" gradientTransform="matrix(1.5767 -.34694 .23734 1.1836 -822.12 572.61)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient9015"/>
+  <radialGradient id="radialGradient2820" cx="1514" cy="-242.04" r="25.379" fx="1510.8" fy="-244.91" gradientTransform="matrix(1.5767 -.34694 .23734 1.1836 -822.12 572.61)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient10959"/>
+  <linearGradient id="linearGradient2826" x1="1531.7" x2="1516.6" y1="-294.2" y2="-258.55" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient9015"/>
+  <radialGradient id="radialGradient2828" cx="1005.1" cy="-231.96" r="19.922" fx="1003.9" fy="-217.38" gradientTransform="matrix(1 0 0 .54412 0 -105.75)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7974"/>
+  <linearGradient id="linearGradient2836" x1="871.22" x2="922.89" y1="-296.4" y2="-253.66" gradientTransform="matrix(-.62843 -.03801 -.038098 .62696 671.45 277.38)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient9015"/>
+  <linearGradient id="linearGradient2838" x1="1303.7" x2="1317.4" y1="-279.2" y2="-290.21" gradientUnits="userSpaceOnUse">
+   <stop offset="0"/>
+   <stop stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2840" x1="1069.7" x2="1075.2" y1="-301.57" y2="-301.57" gradientTransform="matrix(.78467 0 -.0086396 .5282 -782.58 211.76)" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient9182"/>
+  <linearGradient id="linearGradient2842" x1="1587.5" x2="1603.3" y1="-287.56" y2="-287.56" gradientTransform="matrix(.78467 0 0 .78284 -1194.7 282.26)" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient9182"/>
+  <linearGradient id="linearGradient2844" x1="1308" x2="1311.5" y1="-275" y2="-291.92" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5595"/>
+  <linearGradient id="linearGradient2846" x1="1074.8" x2="1079" y1="-311.69" y2="-302.51" gradientTransform="matrix(.78467 0 0 .78284 -780.29 287.77)" gradientUnits="userSpaceOnUse">
+   <stop offset="0"/>
+   <stop stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2852" x1="1303" x2="1307.9" y1="-275.4" y2="-280.13" gradientUnits="userSpaceOnUse">
+   <stop offset="0"/>
+   <stop stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <filter id="filter3606">
+   <feGaussianBlur stdDeviation="0.50964986"/>
+  </filter>
+ </defs>
+ <g transform="translate(.85253 -30.839)">
+  <path d="m-106.39 44.124v-2.7947 2.7947z" fill="#fff" fill-opacity=".75688"/>
+  <path transform="translate(-.85253 30.839)" d="m128 122a64 6 0 11-128 0 64 6 0 11128 0z" fill="url(#radialGradient10965)" opacity=".12821"/>
+  <path transform="matrix(-1 0 0 1 127.15 30.839)" d="m128 122a64 6 0 11-128 0 64 6 0 11128 0z" fill="url(#radialGradient10965)" opacity=".12821"/>
+  <g transform="matrix(.99896 0 0 .96501 -.79916 32.803)">
+   <g transform="matrix(-1.0023 0 0 1 125.81 1.9754)">
+    <g>
+     <path d="m85.21 29.166c3.1432.19363 5.6834 2.0221 6.6487 4.4797l1.5657 3.785.41076 1.1144c.21625.78097.29517 1.6045.21348 2.4537-.4079 4.2402-4.6514 7.4404-9.4702 7.1436-4.5883-.28265-8.0496-3.6364-8.0184-7.6167l.00451-.20642.28684-4.8077c.00073-.007997.00064-.015763.00142-.023762.3605-3.7516 4.106-6.5837 8.3572-6.3218z" fill="url(#linearGradient2724)"/>
+     <rect transform="matrix(-.23044 .098216 .096659 .23415 332.26 119.05)" x="758.11" y="-703.21" width="7.9258" height="28.853" ry="0" clip-path="url(#clipPath7001)" fill="url(#linearGradient2726)" filter="url(#filter7023)" opacity=".56777"/>
+     <path transform="matrix(-.35272 -.021728 -.029857 .31036 615.22 155.68)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z" fill="#312f30"/>
+     <path transform="matrix(-.32823 -.02022 -.027774 .28865 578.44 147.8)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z" clip-path="url(#clipPath6641)" filter="url(#filter6637)" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.1006"/>
     </g>
+    <path transform="matrix(-.25133 -.013787 -.016107 .27864 333.81 124.48)" d="m1021.2-275.25c-5.975-4.1368-21.075-5.4231-28.75-2.5" fill="none" filter="url(#filter7845)" stroke="url(#linearGradient2728)" stroke-width="1.3305"/>
+   </g>
+   <g transform="matrix(1.0023 0 0 1 1.762 2.1484)">
+    <g>
+     <path d="m85.21 29.166c3.1432.19363 5.6834 2.0221 6.6487 4.4797l1.5657 3.785.41076 1.1144c.21625.78097.29517 1.6045.21348 2.4537-.4079 4.2402-4.6514 7.4404-9.4702 7.1436-4.5883-.28265-8.0496-3.6364-8.0184-7.6167l.00451-.20642.28684-4.8077c.00073-.007997.00064-.015763.00142-.023762.3605-3.7516 4.106-6.5837 8.3572-6.3218z" fill="url(#linearGradient2724)"/>
+     <rect transform="matrix(-.23044 .098216 .096659 .23415 332.26 119.05)" x="758.11" y="-703.21" width="7.9258" height="28.853" ry="0" clip-path="url(#clipPath7001)" fill="url(#linearGradient2726)" filter="url(#filter7023)" opacity=".56777"/>
+     <path transform="matrix(-.35272 -.021728 -.029857 .31036 615.22 155.68)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z" fill="#312f30"/>
+     <path transform="matrix(-.32823 -.02022 -.027774 .28865 578.44 147.8)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z" clip-path="url(#clipPath6641)" filter="url(#filter6637)" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.1006"/>
+    </g>
+    <path transform="matrix(-.25133 -.013787 -.016107 .27864 333.81 124.48)" d="m1021.2-275.25c-5.975-4.1368-21.075-5.4231-28.75-2.5" fill="none" filter="url(#filter7845)" stroke="url(#linearGradient2728)" stroke-width="1.3305"/>
+   </g>
+   <g>
+    <path d="m37.707 36.355c-1.6892.068006-3.3628.60428-4.7823 1.5228-2.0256 1.3106-3.0427 3.6795-3.7405 6.0849-5.4238.56715-12.274 2.3787-16.562 10.805l-5.3597 13.468.058897-.00326c-.035653.068684-.071614.13302-.10691.2025l37.787 16.192 8.8791-.49132c4.8804-.27005 7.5524-5.5374 7.8542-10.421l.019581-.001087-.006548-.11759c.010451-.19248.004785-.37968.00768-.57053l.010955-.15788c.001134-.24299.01001-.48852-.001071-.72731l.154-12.472c.19221-2.7475-.43812-5.3808-1.9507-6.7333l-16.193-14.457c-1.7142-1.5305-3.8968-2.209-6.0688-2.1215z" fill="url(#linearGradient2736)" fill-rule="evenodd"/>
+    <rect transform="matrix(.60277 .18133 -.18175 .60137 -630.6 231.69)" x="924.42" y="-612.9" width="15.556" height="39.598" clip-path="url(#clipPath6050)" fill="url(#linearGradient2738)" filter="url(#filter6035)" opacity=".7326"/>
+    <path d="m44.95 84.62 8.8899-.49192c7.8711-.43554 10.034-13.846 5.6967-17.725l-17.91-15.99c-3.3708-3.0096-8.4299-2.9827-12.019-.66049-2.2406 1.4497-3.354 4.078-4.1259 6.7388-5.9992.62732-13.574 2.6266-18.317 11.947l37.785 16.181z" fill="#3d3b3c" fill-rule="evenodd"/>
+    <path transform="matrix(.62861 -.034784 .034865 .62715 -613.14 288.28)" d="m1049.3-326.31c-3.121-.04706-6.2577.7292-8.9687 2.2812-3.8685 2.2146-6.2168 6.0016-7.75 10.375-7.5939.37256-17.004 3.7254-24.813 11l-4.4687 7.4375c8.3388-14.119 20.438-16.596 29.938-17.062 1.4589-4.1617 3.4437-8.2364 7.125-10.344 5.8967-3.3758 13.919-2.9869 19 2.0938l27 27c2.6589 2.6629 3.4978 7.7308 2.6875 12.812.0577-.33334.1171-.66706.1563-1h.0312v-.1875c.0335-.30506.041-.60314.0625-.90625l.0313-.25c.0232-.38617.0591-.77568.0624-1.1562l.5626-7.7929c-.4313-.84136-.9435-1.5988-1.5626-2.2188l-28.094-27.582c-3.0032-3.0032-6.9873-4.4395-11-4.5zm35.094 56.25c-.3665.42403-.7492.81668-1.1562 1.1875.4071-.37038.7899-.76283 1.1562-1.1875zm-5.4062 3.7188c-.293.09401-.6019.15051-.9062.21875.3045-.06641.6131-.12651.9062-.21875zm-1.0625.28125c-.2978.06173-.5977.08907-.9063.125.3035-.0341.6133-.0659.9063-.125z" fill="url(#linearGradient2740)" fill-rule="evenodd" filter="url(#filter5622)"/>
+   </g>
+   <g transform="matrix(.62861 -.034784 .034865 .62715 -641.44 292.52)">
+    <path transform="matrix(1.4082 0 0 1.3269 -724.5 90.279)" d="m1314.2-281.5a6.2336 6.2336 0 11-12.467 0 6.2336 6.2336 0 1112.467 0z" fill="#1f1f1f" filter="url(#filter5698)"/>
+    <path transform="matrix(1.265 0 0 1.192 -537.19 53.17)" d="m1314.5-281.5a6.5 6.5 0 11-13 0 6.5 6.5 0 1113 0z" fill="url(#linearGradient2742)"/>
+   </g>
+   <g>
+    <path transform="matrix(.7569 -.041883 .039559 .71157 -927.77 331.88)" d="m1314.1-281.5a6.1105 6.1105 0 11-12.221 0 6.1105 6.1105 0 1112.221 0z" fill="#3b3b3b" filter="url(#filter5698)"/>
+    <path transform="matrix(.67993 -.037624 .035536 .63921 -828.19 306.41)" d="m1314.5-281.5a6.5 6.5 0 11-13 0 6.5 6.5 0 1113 0z" fill="url(#linearGradient2742)"/>
+    <path d="m44.95 84.62 8.8899-.49192c7.8711-.43554 10.034-13.846 5.6967-17.725l-17.91-15.99c-3.3708-3.0096-8.4299-2.9827-12.019-.66049-2.2406 1.4497-3.354 4.078-4.1259 6.7388-5.9992.62732-13.574 2.6266-18.317 11.947l37.785 16.181z" fill="url(#radialGradient2746)" fill-rule="evenodd"/>
+    <path transform="matrix(.62861 -.034784 .034865 .62715 -678.52 291.9)" d="m1152.9-323.81c-2.9195-.04402-5.8702.7044-8.4062 2.1562-3.6188 2.0716-5.5659 6.0651-7 10.156-9.4074.46155-21.391 2.9395-29.594 17.094l.8973.34467c7.8807-13.407 20.027-16.1 29.02-16.541 1.3786-3.9323 3.4484-7.79 6.9268-9.7812 5.5716-3.1897 13.137-2.447 17.937 2.3536l25.5 26.03c1.5803 1.9431 1.8311 26.156-10 26.156h1.125c12.309 1e-5 16.832-20.783 10.406-27.219l-26.531-26.531c-2.8093-2.8094-6.5275-4.1622-10.281-4.2188z" clip-path="url(#clipPath5757)" fill="url(#linearGradient2748)" fill-rule="evenodd" filter="url(#filter5753)" opacity=".82418"/>
+    <rect transform="matrix(.77403 .63315 -.8117 .58407 0 0)" x="95.236" y="25.318" width="1.3015" height="6.2908"/>
+   </g>
+   <g transform="matrix(.62861 -.034784 .034865 .62715 -609.11 272.49)">
+    <path transform="matrix(.23493 0 0 .22137 740.8 -231.72)" d="m1314.1-281.5a6.1105 6.1105 0 11-12.221 0 6.1105 6.1105 0 1112.221 0z" filter="url(#filter5698)"/>
+    <path transform="matrix(.21104 0 0 .19886 772.04 -237.91)" d="m1314.5-281.5a6.5 6.5 0 11-13 0 6.5 6.5 0 1113 0z" fill="url(#linearGradient2742)"/>
+    <rect transform="matrix(.73701 .67588 -.84221 .53916 0 0)" x="328.35" y="-957.89" width=".4037" height="1.9511"/>
+   </g>
+   <g transform="matrix(.62861 -.034784 .034865 .62715 -620.04 276.43)">
+    <path transform="matrix(.23493 0 0 .22137 740.8 -231.72)" d="m1314.1-281.5a6.1105 6.1105 0 11-12.221 0 6.1105 6.1105 0 1112.221 0z" filter="url(#filter5698)"/>
+    <path transform="matrix(.21104 0 0 .19886 772.04 -237.91)" d="m1314.5-281.5a6.5 6.5 0 11-13 0 6.5 6.5 0 1113 0z" fill="url(#linearGradient2742)"/>
+    <rect transform="matrix(.73701 .67588 -.84221 .53916 0 0)" x="328.35" y="-957.89" width=".4037" height="1.9511"/>
+   </g>
+   <path transform="matrix(.62861 -.034784 .034865 .62715 -613.14 288.28)" d="m1040.1-331.88c-4.4841.2264-16.599 1.4724-19.781 7.1875l3.8437 10.781 8.9063 2.0938 7.0312-20.062z" clip-path="url(#clipPath5917)" fill="url(#linearGradient2754)" fill-rule="evenodd" filter="url(#filter5911)"/>
+   <g fill="none">
+    <path transform="matrix(.62861 -.034784 .034865 .62715 -613.14 288.28)" d="m1046.9-340.8c5.3474-3.0873 12.651-1.9894 16.276 1.6359l6.6162 6.5199" clip-path="url(#clipPath5983)" filter="url(#filter5977)" opacity=".7326" stroke="url(#radialGradient2756)" stroke-width="1px"/>
+    <path transform="matrix(.63452 -.035111 .035248 .63403 -619.47 290.41)" d="m1088.2-312.41-24.406-24.406c-2.5837-2.5837-5.9854-3.8542-9.4376-3.9062-2.6849-.04048-5.3864.66479-7.7187 2-3.328 1.9052-5.1499 5.5813-6.4687 9.3438-8.6516.42447-20.113 2.7891-27.657 15.806" clip-path="url(#clipPath7262)" filter="url(#filter6072)" opacity=".58242" stroke="url(#linearGradient2758)" stroke-width=".59395"/>
+    <path transform="matrix(.62861 -.034784 .034865 .62715 -613.14 288.28)" d="m1037.5-321.53c2.9969-3.0368 7.1114-4.6025 10.878-4.4288" filter="url(#filter6198)" stroke="url(#radialGradient2760)" stroke-width="1px"/>
+    <path transform="matrix(.62861 -.034784 .034865 .62715 -601.12 277.55)" d="m999.92-306.62-10.607 19.799" filter="url(#filter7256)" stroke="url(#linearGradient2762)" stroke-width="1px"/>
+   </g>
+   <g transform="matrix(.62843 .03801 -.038098 .62696 -506.29 193.24)">
+    <g>
+     <path d="m930.46-306.72c2.6849-.04048 5.3864.66479 7.7187 2 3.328 1.9052 5.1499 5.5813 6.4687 9.3438 8.6516.42447 19.675 2.7017 27.219 15.719l9.6875 20.938h-.0937c.0626.10604.1253.20514.1874.3125l-58.5 29.062h-14.125c-7.7637 1e-5-12.466-8.1381-13.375-15.875h-.0312v-.1875c-.0335-.30506-.041-.60314-.0625-.90625l-.0313-.25c-.0232-.38617-.0589-.77568-.0624-1.1562l-1.3438-19.812c-.5471-4.3506.2204-8.592 2.5-10.875l24.406-24.406c2.5837-2.5837 5.9854-3.8542 9.4376-3.9062z" fill="url(#linearGradient2764)" fill-rule="evenodd"/>
+     <rect transform="matrix(-.93997 .34126 .34126 .93997 2007.6 -55)" x="924.42" y="-612.9" width="15.556" height="39.598" clip-path="url(#clipPath6050)" fill="url(#linearGradient2738)" filter="url(#filter6035)" opacity=".7326"/>
+     <path d="m923.22-229.36h-14.142c-12.521 0-17.134-21.128-10.597-27.674l26.994-26.994c5.0806-5.0806 13.106-5.4829 19.003-2.1071 3.6812 2.1074 5.6787 6.1876 7.1376 10.349 9.5696.4695 21.758 2.9813 30.103 17.38l-58.497 29.046z" fill="#3d3b3c" fill-rule="evenodd"/>
+     <path transform="matrix(-1 0 0 1 1984.9 36.5)" d="m1049.3-326.31c-3.121-.04706-6.2577.7292-8.9687 2.2812-3.8685 2.2146-6.2168 6.0016-7.75 10.375-7.5939.37256-17.004 3.7254-24.813 11l-4.4687 7.4375c8.3388-14.119 20.438-16.596 29.938-17.062 1.4589-4.1617 3.4437-8.2364 7.125-10.344 5.8967-3.3758 13.919-2.9869 19 2.0938l27 27c2.6589 2.6629 3.4978 7.7308 2.6875 12.812.0577-.33334.1171-.66706.1563-1h.0312v-.1875c.0335-.30506.041-.60314.0625-.90625l.0313-.25c.0232-.38617.0591-.77568.0624-1.1562l.5626-7.7929c-.4313-.84136-.9435-1.5988-1.5626-2.2188l-28.094-27.582c-3.0032-3.0032-6.9873-4.4395-11-4.5zm35.094 56.25c-.3665.42403-.7492.81668-1.1562 1.1875.4071-.37038.7899-.76283 1.1562-1.1875zm-5.4062 3.7188c-.293.09401-.6019.15051-.9062.21875.3045-.06641.6131-.12651.9062-.21875zm-1.0625.28125c-.2978.06173-.5977.08907-.9063.125.3035-.0341.6133-.0659.9063-.125z" fill="url(#linearGradient2740)" fill-rule="evenodd" filter="url(#filter5622)"/>
+    </g>
+    <g transform="translate(-204.63 40.743)">
+     <path transform="matrix(1.4082 0 0 1.3269 -724.5 90.279)" d="m1314.2-281.5a6.2336 6.2336 0 11-12.467 0 6.2336 6.2336 0 1112.467 0z" fill="#1f1f1f" filter="url(#filter5698)"/>
+     <path transform="matrix(1.265 0 0 1.192 -537.19 53.17)" d="m1314.5-281.5a6.5 6.5 0 11-13 0 6.5 6.5 0 1113 0z" fill="url(#linearGradient2742)"/>
+    </g>
+    <g>
+     <path transform="matrix(1.2041 0 0 1.1346 -662.2 78.137)" d="m1314.1-281.5a6.1105 6.1105 0 11-12.221 0 6.1105 6.1105 0 1112.221 0z" fill="#3b3b3b" filter="url(#filter5698)"/>
+     <path transform="matrix(1.0816 0 0 1.0192 -502.03 46.406)" d="m1314.5-281.5a6.5 6.5 0 11-13 0 6.5 6.5 0 1113 0z" fill="url(#linearGradient2742)"/>
+     <path transform="matrix(-1 0 0 1 2088.9 36.5)" d="m1152.9-323.81c-2.9195-.04402-5.8702.7044-8.4062 2.1562-3.6188 2.0716-5.5659 6.0651-7 10.156-9.4074.46155-21.391 2.9395-29.594 17.094l.8973.34467c7.8807-13.407 20.027-16.1 29.02-16.541 1.3786-3.9323 3.4484-7.79 6.9268-9.7812 5.5716-3.1897 13.137-2.447 17.937 2.3536l25.5 26.03c1.5803 1.9431 1.8311 26.156-10 26.156h1.125c12.309 1e-5 16.832-20.783 10.406-27.219l-26.531-26.531c-2.8093-2.8094-6.5275-4.1622-10.281-4.2188z" clip-path="url(#clipPath5757)" fill="url(#linearGradient2748)" fill-rule="evenodd" filter="url(#filter5753)" opacity=".82418"/>
+     <rect transform="matrix(.73701 .67588 -.84221 .53916 0 0)" x="298.59" y="-826.48" width="2.0691" height="10"/>
+    </g>
+    <g transform="matrix(-1 0 0 1 1977.1 11.751)">
+     <path transform="matrix(.23493 0 0 .22137 740.8 -231.72)" d="m1314.1-281.5a6.1105 6.1105 0 11-12.221 0 6.1105 6.1105 0 1112.221 0z" filter="url(#filter5698)"/>
+     <path transform="matrix(.21104 0 0 .19886 772.04 -237.91)" d="m1314.5-281.5a6.5 6.5 0 11-13 0 6.5 6.5 0 1113 0z" fill="url(#linearGradient2742)"/>
+     <rect transform="matrix(.73701 .67588 -.84221 .53916 0 0)" x="328.35" y="-957.89" width=".4037" height="1.9511"/>
+    </g>
+    <g transform="matrix(-1 0 0 1 1994.8 17.055)">
+     <path transform="matrix(.23493 0 0 .22137 740.8 -231.72)" d="m1314.1-281.5a6.1105 6.1105 0 11-12.221 0 6.1105 6.1105 0 1112.221 0z" filter="url(#filter5698)"/>
+     <path transform="matrix(.21104 0 0 .19886 772.04 -237.91)" d="m1314.5-281.5a6.5 6.5 0 11-13 0 6.5 6.5 0 1113 0z" fill="url(#linearGradient2742)"/>
+     <rect transform="matrix(.73701 .67588 -.84221 .53916 0 0)" x="328.35" y="-957.89" width=".4037" height="1.9511"/>
+    </g>
+    <path transform="matrix(-1 0 0 1 1984.9 36.5)" d="m1040.1-331.88c-4.4841.2264-9.5988.97243-14.531 3.4375l-.6563 1.7812 8.1563 14.844 7.0312-20.062z" clip-path="url(#clipPath5917)" fill="url(#linearGradient2780)" fill-rule="evenodd" filter="url(#filter5911)"/>
+    <g fill="none">
+     <path transform="matrix(-1 0 0 1 1984.9 36.5)" d="m1046.9-340.8c5.3474-3.0873 12.651-1.9894 16.276 1.6359l6.6162 6.5199" clip-path="url(#clipPath5983)" filter="url(#filter5977)" opacity=".7326" stroke="url(#radialGradient2756)" stroke-width="1px"/>
+     <path transform="matrix(-1.0094 0 0 1.011 1995.1 39.328)" d="m1088.2-312.41-24.406-24.406c-2.5837-2.5837-5.9854-3.8542-9.4376-3.9062-2.6849-.04048-5.3864.66479-7.7187 2-3.328 1.9052-5.1499 5.5813-6.4687 9.3438-8.6516.42447-19.675 2.7017-27.219 15.719" filter="url(#filter6072)" opacity=".58242" stroke="url(#linearGradient2758)" stroke-width=".59395"/>
+     <path transform="matrix(-1 0 0 1 1984.9 36.5)" d="m1037.5-321.53c2.9969-3.0368 7.1114-4.6025 10.878-4.4288" filter="url(#filter6198)" stroke="url(#radialGradient2786)" stroke-width="1px"/>
+    </g>
+   </g>
+   <path d="m53.569 48.146s4.9696-3.7524 10.146-3.7524c5.7744 0 10.059 3.927 10.059 3.927l-5.773 5.6723s-1.8369-1.3963-4.0236-1.4835c-2.1868-.087263-4.7233 1.1345-4.7233 1.1345l-5.6856-5.4978z" fill="url(#linearGradient2788)" fill-rule="evenodd"/>
+   <g transform="matrix(.62861 -.034784 .034865 .62715 -601.12 277.55)">
+    <g>
+     <path d="m1008.2-293.5c-12.601 0-23.183 6.5728-27.625 16l-7.1562 14.5-1.9063 4.2812c-1.0499 3.0176-1.5614 6.2359-1.4375 9.5938.6188 16.767 16.806 30.375 36.125 30.375 18.395 0 33.02-12.345 33.844-28l.0312-.8125v-18.969c-.001-.03161.0012-.06212 0-.09375-.5459-14.835-14.832-26.875-31.875-26.875z" fill="url(#linearGradient2790)"/>
+     <rect transform="matrix(.89707 .4419 -.4419 .89707 0 0)" x="758.11" y="-703.21" width="7.9258" height="28.853" ry="0" clip-path="url(#clipPath7001)" fill="url(#linearGradient2726)" filter="url(#filter7023)" opacity=".56777"/>
+     <path transform="matrix(1.4141 0 .045294 1.2273 -1139 75.489)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z" fill="#312f30"/>
+    </g>
+    <path transform="matrix(1.3159 0 .04215 1.1414 -990.15 53.404)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z" clip-path="url(#clipPath6641)" fill="none" filter="url(#filter6637)" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.1006"/>
+    <g>
+     <path transform="translate(88.9 -.1)" d="m913.25-314.25c-6.3437 0-21.674 13.424-10.469 25.281 19.695-4.2016 40.209 18.327 49.219 33.719l11.125-5.5312c14.999 3.9684 2.7512-14.062 2.75-14.094-.54593-14.835-35.582-39.375-52.625-39.375z" clip-path="url(#clipPath6965)" filter="url(#filter6959)" opacity=".71062"/>
+     <path transform="matrix(1.2046 0 .038584 1.0455 -821.34 29.898)" d="m1524.8-289.88c-14.002 0-25.375 11.373-25.375 25.375s11.373 25.375 25.375 25.375 25.375-11.373 25.375-25.375-11.373-25.375-25.375-25.375zm0 1.25c13.322 0 24.125 10.803 24.125 24.125s-10.907 22.772-24.228 22.772-24.022-9.4504-24.022-22.772 10.803-24.125 24.125-24.125z" fill="url(#radialGradient2794)" filter="url(#filter7328)"/>
+     <path transform="matrix(1.1644 0 .037298 1.0106 -760.48 19.801)" d="m1524.8-289.88c-14.002 0-25.375 11.373-25.375 25.375s11.373 25.375 25.375 25.375 25.375-11.373 25.375-25.375-11.373-25.375-25.375-25.375zm0 1.25c13.322 0 24.125 10.803 24.125 24.125s-11.138 18.137-24.46 18.137-23.79-4.8151-23.79-18.137 10.803-24.125 24.125-24.125z" fill="url(#radialGradient2796)"/>
+    </g>
+    <path transform="matrix(1.0072 .006665 -.0020689 1.0993 -7.4728 20.969)" d="m1021.2-275.25c-5.975-4.1368-21.075-5.4231-28.75-2.5" fill="none" filter="url(#filter7845)" stroke="url(#linearGradient2728)" stroke-width="1.3305"/>
+    <path transform="matrix(1.1054 0 .035409 .95943 -671.05 3.5392)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z"/>
+    <path transform="matrix(1.1054 0 .035409 .95943 -671.05 3.5392)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z" fill="url(#radialGradient9002)"/>
+    <path transform="matrix(1.1439 0 .036641 .99291 -729.37 12.671)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z" fill="none" stroke="url(#linearGradient2802)" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.0031"/>
+    <path d="m1025-231.96a19.922 8.0078 0 11-39.844 0 19.922 8.0078 0 1139.844 0z" fill="url(#radialGradient2804)" filter="url(#filter8002)"/>
+    <g transform="translate(138.99)" clip-path="url(#clipPath8998)">
+     <path transform="matrix(.95567 0 0 .95567 -96.02 -10.419)" d="m979.03-261.5c-.0814.87937-.1271 1.7819-.0937 2.6875.4838 13.108 13.147 23.75 28.25 23.75 15.103 0 26.952-10.642 26.469-23.75-.0151-.40962-.0239-.81421-.0624-1.2188-1.114 11.834-11.968 22.234-26.016 22.234-14.631-1e-5-27.351-11.162-28.547-23.703z" fill="url(#linearGradient2806)" filter="url(#filter7958)" opacity=".85714"/>
+     <path transform="matrix(.95567 0 0 .95567 -93.285 -23.31)" d="m979.03-261.5c-.0814.87937-.1271 1.7819-.0937 2.6875.4838 13.108 13.147 23.75 28.25 23.75 15.103 0 26.952-10.642 26.469-23.75-.0151-.40962-.0239-.81421-.0624-1.2188-1.114 11.834-14.012 23.052-28.059 23.052-14.631-1e-5-25.307-11.98-26.503-24.521z" fill="url(#linearGradient2806)" filter="url(#filter7958)"/>
+     <path transform="matrix(1.0246 0 0 1.0432 -162.62 -.39983)" d="m979.03-261.5c-.0814.87937-.1271 1.7819-.0937 2.6875.4838 13.108 12.204 23.353 27.306 23.353 15.103 1e-5 27.896-10.245 27.412-23.353-.0151-.40962-.0239-.81421-.0624-1.2188-1.114 11.834-10.008 23.052-28.059 23.052-14.631 0-25.307-11.98-26.503-24.521z" opacity=".37363"/>
+    </g>
+    <path transform="translate(-5.8005 -7.1816)" d="m1034.1-242.68a4.9718 4.9718 0 11-9.9437 0 4.9718 4.9718 0 119.9437 0z" fill="url(#radialGradient2810)"/>
+    <path d="m1003.9-273.97c-8.9847 0-16.85 3.7523-21.625 9.5625 2.9716 6.218 12.276 10.75 23.25 10.75 9.8905 0 18.396-3.657 22.156-8.9375-5.0599-6.824-13.896-11.375-23.781-11.375z" fill="url(#linearGradient2812)"/>
+   </g>
+   <g>
+    <path transform="matrix(-.62843 -.03801 -.038098 .62696 672.29 277.37)" d="m913.25-314.25c-6.3437 0-21.674 13.424-10.469 25.281 19.695-4.2016 40.209 18.327 49.219 33.719l11.125-5.5312c14.999 3.9684 2.7512-14.062 2.75-14.094-.54593-14.835-35.582-39.375-52.625-39.375z" clip-path="url(#clipPath6965)" filter="url(#filter6959)" opacity=".71062"/>
+    <path d="m105.73 58.472c7.919.47897 14.319 5.0021 16.751 11.081l3.9447 9.3629 1.0349 2.7566c.54482 1.9319.74365 3.969.53786 6.0696-1.0277 10.489-11.719 18.405-23.859 17.671-11.56-.69918-20.28-8.9952-20.202-18.841l.011348-.51059.72268-11.893c.001832-.019781.001612-.038993.003571-.058778.90825-9.2802 10.345-16.286 21.055-15.638z" fill="url(#linearGradient2814)"/>
+    <rect transform="matrix(-.58057 .24295 .24352 .57922 728.16 280.81)" x="758.11" y="-703.21" width="7.9258" height="28.853" ry="0" clip-path="url(#clipPath7001)" fill="url(#linearGradient2726)" filter="url(#filter7023)" opacity=".56777"/>
+    <path transform="matrix(-.88863 -.053748 -.075221 .76773 1441 371.43)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z" fill="#312f30"/>
+   </g>
+   <path transform="matrix(-.82695 -.050017 -.069974 .71402 1348.4 351.93)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z" clip-path="url(#clipPath6641)" fill="none" filter="url(#filter6637)" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.1006"/>
+   <path transform="matrix(-.75698 -.045785 -.064077 .65399 1243.2 330.77)" d="m1524.8-289.88c-14.002 0-25.375 11.373-25.375 25.375s11.373 25.375 25.375 25.375 25.375-11.373 25.375-25.375-11.373-25.375-25.375-25.375zm0 1.25c13.322 0 24.125 10.803 24.125 24.125s-10.907 22.772-24.228 22.772-24.022-9.4504-24.022-22.772 10.803-24.125 24.125-24.125z" fill="url(#radialGradient2818)" filter="url(#filter3606)"/>
+   <path transform="matrix(-.73176 -.04426 -.061942 .6322 1205.3 322.13)" d="m1524.8-289.88c-14.002 0-25.375 11.373-25.375 25.375s11.373 25.375 25.375 25.375 25.375-11.373 25.375-25.375-11.373-25.375-25.375-25.375zm0 1.25c13.322 0 24.125 10.803 24.125 24.125s-11.138 18.137-24.46 18.137-23.79-4.8151-23.79-18.137 10.803-24.125 24.125-24.125z" fill="url(#radialGradient2820)"/>
+   <path transform="matrix(-.63319 -.034104 -.040579 .68927 732.05 294.24)" d="m1021.2-275.25c-5.975-4.1368-21.075-5.4231-28.75-2.5" fill="none" filter="url(#filter7845)" stroke="url(#linearGradient2728)" stroke-width="1.3305"/>
+   <path transform="matrix(-.69469 -.042018 -.058804 .60018 1149.7 308.53)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z"/>
+   <path transform="matrix(-.69469 -.042018 -.058804 .60018 1149.7 308.53)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z" fill="url(#radialGradient9002)"/>
+   <path transform="matrix(-.71886 -.04348 -.060854 .62112 1186 316.48)" d="m1549.5-264.5a24.75 24.75 0 11-49.5 0 24.75 24.75 0 1149.5 0z" fill="none" stroke="url(#linearGradient2826)" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.0031"/>
+   <path transform="matrix(-.62843 -.03801 -.038098 .62696 728.16 280.81)" d="m1025-231.96a19.922 8.0078 0 11-39.844 0 19.922 8.0078 0 1139.844 0z" fill="url(#radialGradient2828)" filter="url(#filter8002)"/>
+   <g transform="matrix(-.62843 -.03801 -.038098 .62696 640.81 275.53)" clip-path="url(#clipPath8998)">
+    <path transform="matrix(.95567 0 0 .95567 -96.02 -10.419)" d="m979.03-261.5c-.0814.87937-.1271 1.7819-.0937 2.6875.4838 13.108 13.147 23.75 28.25 23.75 15.103 0 26.952-10.642 26.469-23.75-.0151-.40962-.0239-.81421-.0624-1.2188-1.114 11.834-11.968 22.234-26.016 22.234-14.631-1e-5-27.351-11.162-28.547-23.703z" fill="url(#linearGradient2806)" filter="url(#filter7958)" opacity=".85714"/>
+    <path transform="matrix(.95567 0 0 .95567 -93.285 -23.31)" d="m979.03-261.5c-.0814.87937-.1271 1.7819-.0937 2.6875.4838 13.108 13.147 23.75 28.25 23.75 15.103 0 26.952-10.642 26.469-23.75-.0151-.40962-.0239-.81421-.0624-1.2188-1.114 11.834-14.012 23.052-28.059 23.052-14.631-1e-5-25.307-11.98-26.503-24.521z" fill="url(#linearGradient2806)" filter="url(#filter7958)"/>
+    <path transform="matrix(1.0246 0 0 1.0432 -162.62 -.39983)" d="m979.03-261.5c-.0814.87937-.1271 1.7819-.0937 2.6875.4838 13.108 12.204 23.353 27.306 23.353 15.103 1e-5 27.896-10.245 27.412-23.353-.0151-.40962-.0239-.81421-.0624-1.2188-1.114 11.834-10.008 23.052-28.059 23.052-14.631 0-25.307-11.98-26.503-24.521z" opacity=".37363"/>
+   </g>
+   <g>
+    <path transform="matrix(-.62843 -.03801 -.038098 .62696 754.66 277.89)" d="m1034.1-242.68a4.9718 4.9718 0 11-9.9437 0 4.9718 4.9718 0 119.9437 0z" fill="url(#radialGradient2810)" opacity=".64835"/>
+    <path d="m107.74 70.884c5.6462.3415 10.446 2.9931 13.225 6.8173-2.1043 3.7855-8.1243 6.2732-15.02 5.8561-6.2154-.37593-11.421-2.9921-13.583-6.4456 3.4397-4.086 9.1663-6.6035 15.378-6.2278z" fill="url(#linearGradient2836)"/>
+    <path transform="matrix(.73986 -.040622 .038668 .69016 -893.3 296.25)" d="m1314.1-281.5a6.1105 6.1105 0 11-12.221 0 6.1105 6.1105 0 1112.221 0z" clip-path="url(#clipPath10259)" fill="url(#linearGradient2838)" filter="url(#filter10253)"/>
+    <path d="m60.346 47.305c.11087-.72008 1.0781-1.6942 3.3783-1.6942 2.3034 0 3.3329.95537 3.3208 1.6942l.89457 7.6755h-8.5824l.98869-7.6755z" fill="url(#linearGradient2840)"/>
+    <path d="m51.002 56.709s6.1571-4.649 12.571-4.649c7.1541 0 12.462 4.8652 12.462 4.8652l-7.1523 7.0275s-2.2758-1.7299-4.985-1.838c-2.7093-.10812-5.8519 1.4055-5.8519 1.4055l-7.044-6.8113z" fill="url(#linearGradient2842)" fill-rule="evenodd"/>
+    <path transform="matrix(.94336 -.0522 .049303 .88686 -1156.1 375.18)" d="m1314.1-281.5a6.1105 6.1105 0 11-12.221 0 6.1105 6.1105 0 1112.221 0z" fill="#3b3b3b" filter="url(#filter5698)"/>
+    <path transform="matrix(.84742 -.046892 .04429 .79667 -1032 343.44)" d="m1314.5-281.5a6.5 6.5 0 11-13 0 6.5 6.5 0 1113 0z" fill="url(#linearGradient2844)"/>
+    <path d="m60.346 47.305c.11087-.72008 1.0781-1.6942 3.3783-1.6942 2.3034 0 3.3329.95537 3.3208 1.6942l.89457 7.6755h-8.5824l.98869-7.6755z" fill="url(#linearGradient2846)"/>
+   </g>
+   <g transform="matrix(.62861 -.034784 .034865 .62715 -602.5 302.33)">
+    <path transform="matrix(.23493 0 0 .22137 740.8 -231.72)" d="m1314.1-281.5a6.1105 6.1105 0 11-12.221 0 6.1105 6.1105 0 1112.221 0z" filter="url(#filter5698)"/>
+    <path transform="matrix(.21104 0 0 .19886 772.04 -237.91)" d="m1314.5-281.5a6.5 6.5 0 11-13 0 6.5 6.5 0 1113 0z" fill="url(#linearGradient2742)"/>
+    <rect transform="matrix(.73701 .67588 -.84221 .53916 0 0)" x="328.35" y="-957.89" width=".4037" height="1.9511"/>
+   </g>
+   <g transform="matrix(.62861 -.034784 .034865 .62715 -566.23 302.45)">
+    <path transform="matrix(.23493 0 0 .22137 740.8 -231.72)" d="m1314.1-281.5a6.1105 6.1105 0 11-12.221 0 6.1105 6.1105 0 1112.221 0z" filter="url(#filter5698)"/>
+    <path transform="matrix(.21104 0 0 .19886 772.04 -237.91)" d="m1314.5-281.5a6.5 6.5 0 11-13 0 6.5 6.5 0 1113 0z" fill="url(#linearGradient2742)"/>
+    <rect transform="matrix(.73701 .67588 -.84221 .53916 0 0)" x="328.35" y="-957.89" width=".4037" height="1.9511"/>
+   </g>
+   <path transform="matrix(.84742 -.046892 .04429 .79667 -1032 343.44)" d="m1314.5-281.5a6.5 6.5 0 11-13 0 6.5 6.5 0 1113 0z" fill="url(#linearGradient2852)" opacity=".35531"/>
   </g>
+ </g>
 </svg>

--- a/src/util/bticons.cpp
+++ b/src/util/bticons.cpp
@@ -147,7 +147,37 @@ BT_REGULAR_ICON(icon_exit, "exit.svg")
 BT_REGULAR_ICON(icon_export, "export.svg")
 BT_REGULAR_ICON(icon_file_save, "file_save.svg")
 BT_REGULAR_ICON(icon_fileclose, "fileclose.svg")
-BT_REGULAR_ICON(icon_find, "find.svg")
+    // Manually implement the function to force a safe buffer size
+    QIcon const & icon_find() {
+    static QIcon *safeIcon = nullptr;
+
+    if (!safeIcon) {
+        // 1. Instantiate your custom class using the raw filename
+        BtRegularIcon rawIcon(QStringLiteral("find.svg"));
+
+        // 2. Extract a standard pixmap. (Pick a standard safe maximum size, like 128x128)
+        // This forces BtRegularIcon to resolve its internal resource path
+        // and safely reads the image data.
+        QPixmap originalPixmap = rawIcon.pixmap(QSize(128, 128));
+
+        if (!originalPixmap.isNull()) {
+            // 3. Explicitly resize the pixmap. This steps down the internal cache layout
+            // bounds so Qt 6 never triggers the massive buffer calculation warning.
+            QPixmap safePixmap = originalPixmap.scaled(
+                QSize(128, 128),
+                Qt::KeepAspectRatio,
+                Qt::SmoothTransformation
+            );
+            safeIcon = new QIcon(safePixmap);
+        } else {
+            // Fallback to the raw object directly if resolution failed
+            safeIcon = new QIcon(rawIcon);
+        }
+    }
+
+    return *safeIcon;
+}
+
 BT_REGULAR_ICON(icon_flag, "flag.svg")
 BT_REGULAR_ICON(icon_folder_open, "folder-open.svg")
 BT_REGULAR_ICON(icon_folder, "folder.svg")


### PR DESCRIPTION
This pull request reduces the complexity of find.svg and replaces the BT_REGULAR_ICON use for this icon with custom loading code that uses an explicit QPixmap to scale it. This removes several 

WARNING: The requested buffer size is too big, ignoring

messages appearing at startup during toolbar creation.