### PR TITLE
Fix HTML injection in OSIS footnote n attribute

### DIFF
--- a/src/backend/filters/osistohtml.cpp
+++ b/src/backend/filters/osistohtml.cpp
@@ -353,7 +353,7 @@ bool Filters::OsisToHtml::handleToken(sword::SWBuf &buf, const char *token, swor
                     const sword::SWBuf n = tag.getAttribute("n");
 
                     buf.append("\">");
-                    buf.append( (n.length() > 0) ? n.c_str() : "*" );
+                    buf.append( (n.length() > 0) ? QString::fromUtf8(n.c_str()).toHtmlEscaped().toUtf8().constData() : "*" );
                     buf.append("</span> ");
 
                     myUserData->noteTypes.emplace_back(UserData::Footnote);


### PR DESCRIPTION
The `n` (number) attribute from an OSIS <note> XML tag is inserted directly into the HTML output buffer without escaping. A malicious module with `<note n="<script>alert(1)</script>">` could inject arbitrary JavaScript.

This fix uses `QString::toHtmlEscaped()` to properly escape the attribute value before appending it to the buffer.